### PR TITLE
Don't update a tree if it isn't in the DOM yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ function choo () {
       const oldTree = document.querySelector('#' + rootId)
       const newTree = _router(state.app.location, state, send)
       newTree.setAttribute('id', rootId)
-      yo.update(oldTree, newTree)
+      if (oldTree) yo.update(oldTree, newTree)
     }
   }
 


### PR DESCRIPTION
This can occur if the state changes before the first view is rendered per #1, in which case it throws the error `Cannot read property 'nodeType' of null`