### PR TITLE
Fix #37 `rootId` should clear if only `opts` is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,10 @@ function choo () {
   // start the application
   // (str?, obj?) -> DOMNode
   function start (rootId, opts) {
-    if (!opts) opts = rootId
+    if (!opts) {
+      opts = rootId
+      rootId = null
+    }
     opts = opts || {}
     const name = opts.name || 'choo'
     const initialState = {}


### PR DESCRIPTION
`rootId` is optional to `start`, but has lower precedence than `opts`. Currently it is not cleared when the value is passed to `opts`