### PR TITLE
Hash routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,10 @@ following values:
 - __opts.href:__ default: `true`. Handle all relative `<a
   href="<location>"></a>` clicks and update internal `state.location`
   accordingly.
+- __opts.hash:__ default: `false`. Enable a `subscription` to the hash change
+  event, updating the internal `state.location` state whenever the URL hash
+  changes (eg `localhost/#posts/123`). Enabling this option automatically
+  disables `opts.history` and `opts.href`.
 
 ## Errors
 ### Could not find DOM node (#id) to update

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ const history = require('sheet-router/history')
 const sheetRouter = require('sheet-router')
 const document = require('global/document')
 const href = require('sheet-router/href')
+const hash = require('sheet-router/hash')
+const hashMatch = require('hash-match')
 const sendAction = require('send-action')
 const mutate = require('xtend/mutable')
 const assert = require('assert')
@@ -205,6 +207,13 @@ function appInit (opts) {
   // enable HTML5 history API
   if (opts.href !== false) pushLocationSub(href)
   if (opts.history !== false) pushLocationSub(history)
+  if (opts.hash !== false) {
+    pushLocationSub(function (navigate) {
+      hash(function (fragment) {
+        navigate(hashMatch(fragment))
+      })
+    })
+  }
 
   return model
 

--- a/index.js
+++ b/index.js
@@ -189,9 +189,16 @@ function choo () {
 // initial application state model
 // obj -> obj
 function appInit (opts) {
+  var initialLocation
+  if (opts.history !== false) {
+    initialLocation = document.location.href
+  } else {
+    initialLocation = hashMatch(document.location.hash)
+  }
+
   const model = {
     namespace: 'app',
-    state: { location: document.location.href },
+    state: { location: initialLocation },
     subscriptions: [],
     reducers: {
       // handle href links
@@ -206,8 +213,10 @@ function appInit (opts) {
   // enable catching <href a=""></href> links
   // enable HTML5 history API
   if (opts.href !== false) pushLocationSub(href)
-  if (opts.history !== false) pushLocationSub(history)
-  if (opts.hash !== false) {
+  if (opts.history !== false) {
+    pushLocationSub(history)
+  // otherwise enable hash history
+  } else {
     pushLocationSub(function (navigate) {
       hash(function (fragment) {
         navigate(hashMatch(fragment))

--- a/index.js
+++ b/index.js
@@ -192,12 +192,9 @@ function choo () {
 // initial application state model
 // obj -> obj
 function appInit (opts) {
-  var initialLocation
-  if (opts.history !== false) {
-    initialLocation = document.location.href
-  } else {
-    initialLocation = hashMatch(document.location.hash)
-  }
+  const initialLocation = (opts.hash === true)
+    ? hashMatch(document.location.hash)
+    : document.location.href
 
   const model = {
     namespace: 'app',
@@ -213,18 +210,18 @@ function appInit (opts) {
     }
   }
 
-  // enable catching <href a=""></href> links
-  // enable HTML5 history API
-  if (opts.href !== false) pushLocationSub(href)
-  if (opts.history !== false) {
-    pushLocationSub(history)
-  // otherwise enable hash history
-  } else {
+  // if hash routing explicitly enabled, subscribe to it
+  if (opts.hash === true) {
     pushLocationSub(function (navigate) {
       hash(function (fragment) {
         navigate(hashMatch(fragment))
       })
     })
+  // otherwise, subscribe to HTML5 history API
+  } else {
+    if (opts.history !== false) pushLocationSub(history)
+    // enable catching <a href=""></a> links
+    if (opts.href !== false) pushLocationSub(href)
   }
 
   return model

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "license": "MIT",
   "dependencies": {
     "global": "^4.3.0",
+    "hash-match": "^1.0.2",
     "send-action": "^1.1.0",
-    "sheet-router": "^3.0.0",
+    "sheet-router": "^3.1.0",
     "xhr": "^2.2.0",
     "xtend": "^4.0.1",
     "yo-yo": "^1.2.0"


### PR DESCRIPTION
This pull request leverages the recent work of @nlocnila in yoshuawuyts/sheet-router#18 to add hash routing support. The current code works, but could be optimized. Wanted to get feedback on the direction first.

Note that to use this, users must use `app.start(null, {history: false, href: false})`. Otherwise `href` hijacks the anchor tags.