### PR TITLE
Fix order of arguments to effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ function view (params, state, send) {
 
 app.model({
   effects: {
-    login: (state, action, send) => {
+    login: (action, state, send) => {
       http.post('/login', { body: action.data }, (err, res, body) => {
         send('authorize', { payload: body })
       })


### PR DESCRIPTION
This confused me a bit since it was the reverse of the `action` and `state` arguments for reducers.