### PR TITLE
Clarify documentation on id overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ const mainView = (params, state, send) => choo.view`
 `
 ```
 
+_Note_: if an `id` property is defined on the outer-most element it will be
+replaced.
+
 We then bind the view to the `/` route on our application
 ```js
 app.router((route) => [


### PR DESCRIPTION
Was playing around today and couldn't find my element that I was lazily marking with an `id` after it was inserted into the DOM.

Noticed the call to `setAttribute('id', 'choo-root')` and figured this should get called out in the docs probably since it could cause confusion.