### PR TITLE
Allow for naming the rootId with no options

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function choo () {
   // start the application
   // (str?, obj?) -> DOMNode
   function start (rootId, opts) {
-    if (!opts) {
+    if (!opts && typeof rootId !== 'string') {
       opts = rootId
       rootId = null
     }


### PR DESCRIPTION
Right now if you want to name your `rootId` something different, but don't pass
in any options, it doesn't change the name of your `rootId` (see confusion in
github #49.)

This would allow someone to use

```js
const app = choo()
app.start('myRootNode')
```

Rather than having to use

```js
const app = choo()
app.start('myRootNode', {name: 'myRootNode'})
```