### PR TITLE
WIP: browser testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 tmp/
 npm-debug.log*
 .DS_Store
+.sauce-credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp/
 npm-debug.log*
 .DS_Store
 .sauce-credentials.json
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log*
 .DS_Store
 .sauce-credentials.json
 *.swp
+sauce_connect.log
+.zuulrc

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,18 @@
+ui: tape
+browsers:
+  - name: chrome
+    version: latest
+    os: 'Mac 10.11'
+  - name: internet explorer
+    version: 11
+    os: 'Windows 10'
+  - name: firefox
+    version: latest
+    os: 'Mac 10.11'
+  - name: microsoftedge
+    version: latest
+  - name: safari
+    version: latest
+    os: 'Mac 10.11'
+
+

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -14,5 +14,9 @@ browsers:
   - name: safari
     version: latest
     os: 'Mac 10.11'
+browserify:
+  - transform: es2020
+  - transform: sheetify/transform
+
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const fs = require('fs')
+
+module.exports = function (karma) {
+  const glob = 'tests/browser/*.js'
+  const files = [{pattern: glob}]
+
+  const customLaunchers = {
+    SL_Edge: {
+      base: 'SauceLabs',
+      platform: 'Windows 10',
+      browserName: 'microsoftedge'
+    },
+    SL_Firefox: {
+      base: 'SauceLabs',
+      browserName: 'Firefox'
+    },
+    SL_Chrome: {
+      base: 'SauceLabs',
+      browserName: 'Chrome',
+      platform: 'Windows 10'
+    },
+    SL_Safari: {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OSX 10.11'
+    },
+    SL_IE11: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      version: '11'
+    },
+    SL_IE10: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      version: '10'
+    },
+    SL_IE9: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      version: '9'
+    }
+  }
+
+  const sauceConfig = {
+    sauceLabs: {
+      testName: 'choo browser tests',
+      recordScreenshots: false,
+      connectOptions: {
+        port: 5757,
+        logfile: 'sauce_connect.log'
+      },
+      public: 'public'
+    },
+    captureTimeout: 120000,
+    customLaunchers: customLaunchers,
+    browsers: Object.keys(customLaunchers)
+  }
+
+  let config = {
+    frameworks: ['tap', 'browserify'],
+    preprocessors: {
+      [glob]: ['browserify']
+    },
+    reporters: ['dots'],
+    port: 9876,
+    colors: true,
+    logLevel: karma.LOG_INFO,
+    files: files,
+    browserify: {
+      debug: true,
+      transform: ['sheetify/transform', 'es2020']
+    },
+    singleRun: true,
+    browsers: ['Chrome'],
+    captureTimeout: 10000000,
+    browserNoActivityTimeout: 1000000
+  }
+
+  // always run coverage in Travis and use sauce labs to launch browsers
+  if (process.env.TRAVIS) {
+    process.env.COVERAGE = true
+    if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
+      const sauce = JSON.parse(fs.readFileSync('.sauce-credentials.json', 'utf8'))
+      process.env.SAUCE_USERNAME = sauce.user
+      process.env.SAUCE_ACCESS_KEY = sauce.key
+    }
+    config = Object.assign(config, sauceConfig)
+  }
+
+  // add coverage
+  if (process.env.COVERAGE) {
+    config.reporters.push('coverage')
+    config.browserify.transform.push(['browserify-istanbul', {instrumenterConfig: { embedSource: true }}])
+    config.coverageReporter = {type: 'lcov'}
+  }
+
+  // for development setting this variable will open karma and continously
+  // run the test suite when files have changed
+  if (process.env.MULTI_RUN === 'true') {
+    config.singleRun = false
+  }
+
+  if (process.env.IE === 'true') {
+    config.browsers = ['IE']
+  }
+
+  if (process.env.SAFARI === 'true') {
+    config.browsers = ['Safari']
+  }
+
+  karma.set(config)
+}

--- a/package.json
+++ b/package.json
@@ -40,19 +40,12 @@
     "es2020": "^1.0.1",
     "insert-css": "^0.2.0",
     "istanbul": "^0.4.4",
-    "karma": "^0.13.22",
-    "karma-browserify": "^5.0.5",
-    "karma-chrome-launcher": "^1.0.1",
-    "karma-coverage": "^1.0.0",
-    "karma-ie-launcher": "^1.0.0",
-    "karma-safari-launcher": "^1.0.0",
     "karma-sauce-launcher": "^1.0.0",
-    "karma-script-launcher": "^1.0.0",
-    "karma-tap": "^1.0.4",
     "server-router": "^2.1.0",
     "sheetify": "^5.0.0",
     "standard": "^7.1.0",
     "tachyons": "^4.0.0-beta.19",
-    "tape": "^4.5.1"
+    "tape": "^4.5.1",
+    "zuul": "toddself/zuul"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
   "main": "index.js",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev -i xhr",
-    "test": "standard && npm run deps && NODE_ENV=test node tests/*",
-    "test:cov": "standard && npm run deps && NODE_ENV=test istanbul cover tests/*"
+    "test:server": "standard && npm run deps && NODE_ENV=test node tests/server/*",
+    "test:server:cov": "standard && npm run deps && NODE_ENV=test istanbul cover tests/server/*",
+    "test:browser": "standard && npm run deps && NODE_ENV=test karma start",
+    "test:browser:cov": "standard && npm run deps && NODE_ENV=test COVERAGE=true karma start",
+    "test:cov": "npm run test:server:cov && npm run test:browser:cov",
+    "test": "npm run test:server && npm run test:browser"
   },
   "repository": "yoshuawuyts/choo",
   "keywords": [
@@ -30,11 +34,21 @@
   "devDependencies": {
     "bankai": "^2.0.2",
     "browserify": "^13.0.1",
+    "browserify-istanbul": "^2.0.0",
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.5.1",
     "es2020": "^1.0.1",
     "insert-css": "^0.2.0",
-    "istanbul": "^0.4.3",
+    "istanbul": "^0.4.4",
+    "karma": "^0.13.22",
+    "karma-browserify": "^5.0.5",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-coverage": "^1.0.0",
+    "karma-ie-launcher": "^1.0.0",
+    "karma-safari-launcher": "^1.0.0",
+    "karma-sauce-launcher": "^1.0.0",
+    "karma-script-launcher": "^1.0.0",
+    "karma-tap": "^1.0.4",
     "server-router": "^2.1.0",
     "sheetify": "^5.0.0",
     "standard": "^7.1.0",

--- a/tests/browser/frozen-state.js
+++ b/tests/browser/frozen-state.js
@@ -1,0 +1,55 @@
+const tape = require('tape')
+const choo = require('../../')
+
+tape('should render on the client', function (t) {
+  t.test('state should not be mutable', function (t) {
+    t.plan(3)
+
+    const app = choo()
+    const state = {
+      foo: 'baz',
+      beep: 'boop'
+    }
+    app.model({
+      state: state,
+      reducers: {
+        mutate: (action, state) => {
+          state.foo = 'zap'
+          return {}
+        },
+        noMutate: (action, state) => {
+          return {beep: 'poob'}
+        }
+      },
+      effects: {
+        effectMutate: (action, state) => {
+          state.foo = 'zap'
+        }
+      }
+    })
+
+    app.router((route) => [
+      route('/', function (params, state, send) {
+        const okd = (evt) => {
+          if (evt.key === 'a') {
+            send('mutate')
+          } else {
+            send('noMutate')
+          }
+        }
+        return choo.view`<span class="test" onkeydown=${okd}>${state.foo}:${state.beep}</span>`
+      })
+    ])
+    document.body.appendChild(app.start())
+    const $el = document.querySelector('.test')
+    const mutate = new window.KeyboardEvent('keydown', {key: 'a'})
+    const noMutate = new window.KeyboardEvent('keydown', {key: 'b'})
+    const effectMutate = new window.KeyboardEvent('keydown', {key: 'c'})
+    $el.dispatchEvent(mutate)
+    t.equal($el.innerText, 'baz:boop', 'state did not mutate')
+    $el.dispatchEvent(noMutate)
+    t.equal($el.innerText, 'baz:poob', 'state was updated from a return')
+    $el.dispatchEvent(effectMutate)
+    t.equal($el.innerText, 'baz:poob', 'state was not updated from an effect')
+  })
+})

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -1,5 +1,5 @@
 const tape = require('tape')
-const choo = require('../')
+const choo = require('../../')
 
 tape('should render on the server', function (t) {
   t.test('should render a static response', function (t) {


### PR DESCRIPTION
Wanted to get some feedback on this.

Right now the tests will NOT complete in IE nor Safari due to the fact they're using keyboard events to trigger the tests, however, karma adds some baggage here and I want to make sure we're all ready for it.

The upside is that it will run the tests via SauceLabs in a panoply of browsers for us, so we can prove the stuff works (with some minor compiling down to es2020) in those browsers.

Also, this will require @yoshuawuyts to sign up for a free Sauce Labs account and configure Travis thusly. (Just making sure the username and access_key are in the env variables section of travis where the karma config wants them to be.)

Obviously this needs tests too, but this at least lets us start writing them.