### PR TITLE
WIP: Re-configure `npm test` to run all the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Let's create an input box that changes the content of a textbox in real time.
 First we import `choo` and create a new instance:
 ```js
 const choo = require('choo')
+const html = require('choo/html')
 const app = choo()
 ```
 
@@ -136,7 +137,7 @@ Then we create a new view. It has an `h1` tag which displays the current title,
 and an `<input>` field which sends the current value of the text box on every
 input:
 ```js
-const mainView = (params, state, send) => choo.view`
+const mainView = (params, state, send) => html`
   <main>
     <h1>${state.title}</h1>
     <input
@@ -166,6 +167,7 @@ document.body.appendChild(tree)
 And all together now:
 ```js
 const choo = require('choo')
+const html = require('choo/html')
 const app = choo()
 
 app.model({
@@ -175,7 +177,7 @@ app.model({
   }
 })
 
-const mainView = (params, state, send) => choo.view`
+const mainView = (params, state, send) => html`
   <main>
     <h1>${state.title}</h1>
     <input
@@ -338,7 +340,7 @@ Views are also passed the `send` function, which they can use to dispatch action
 
 ```javascript
 const view = (params, state, send) => {
-  return choo.view`
+  return html`
     <div>
       <h1>Total todos: ${state.todos.length}</h1>
       <button onclick=${(e) => send('add', { payload: {title: 'demo'})}>Add</button>
@@ -478,10 +480,11 @@ links they comprise most of what can be done on web pages.
 ```js
 const choo = require('choo')
 const http = require('choo/http')
+const html = require('choo/html')
 const app = choo()
 
 function view (params, state, send) {
-  return choo.view`
+  return html`
     <form onsubmit=${onSubmit}>
       <fieldset>
         <label>username</label>
@@ -521,7 +524,7 @@ app.start()
 If you want a form element to be selected when it's loaded, add the
 [`autofocus`][html-input] property.
 ```js
-const view = choo.view`
+const view = html`
   <form>
     <input type="text" autofocus>
   </form>
@@ -535,7 +538,7 @@ is clicked, the click event is caught, and the value of `href` is passed into
 the router causing a state change. If you want to disable this behavior, set
 `app.start({ href: false })`.
 ```js
-const nav = choo.view`
+const nav = html`
   <a href="/">home</a>
   <a href="/first-link">first link</a>
   <a href="/second-link">second link</a>
@@ -574,10 +577,11 @@ In order to make our `choo` app call `app.start()` in the browser and be
 `require()`-able in Node, we check if [`module.parent`][module-parent] exists:
 ```js
 const choo = require('choo')
+const html = require('choo/html')
 const app = choo()
 
 app.router((route) => [
-  route('/', (params, state, send) => choo.view`
+  route('/', (params, state, send) => html`
     <h1>${state.message}</h1>
   `)
 ])
@@ -603,10 +607,11 @@ dehydrated DOM nodes to make them dynamic, rather than a new DOM tree and
 attaching it to the DOM.
 ```js
 const choo = require('choo')
+const html = require('choo/html')
 const app = choo()
 
 app.router((route) => [
-  route('/', (params, state, send) => choo.view`
+  route('/', (params, state, send) => html`
     <h1 id="app-root">${state.message}</h1>
   `)
 ])
@@ -642,11 +647,6 @@ arguments:
   a signature of `(action, state, send)` where `send` is a reference to
   `app.send()`
 
-### choo.view\`html\`
-Tagged template string HTML builder. See
-[`yo-yo`](https://github.com/maxogden/yo-yo) for full documentation. Views
-should be passed to `app.router()`
-
 ### app.router(params, state, send)
 Creates a new router. See
 [`sheet-router`](https://github.com/yoshuawuyts/sheet-router) for full
@@ -676,6 +676,11 @@ following values:
   event, updating the internal `state.location` state whenever the URL hash
   changes (eg `localhost/#posts/123`). Enabling this option automatically
   disables `opts.history` and `opts.href`.
+
+### choo/html\`html\`
+Tagged template string HTML builder. See
+[`yo-yo`](https://github.com/maxogden/yo-yo) for full documentation. Views
+should be passed to `app.router()`
 
 ## Errors
 ### Could not find DOM node (#id) to update

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ and `reducers`. They're generally grouped around a theme (or domain, if you
 like). To provide some sturdiness to your `models`, they can either be
 namespaced or not. Namespacing means that only state within the model can be
 accessed. Models can still trigger actions on other models, though it's
-recommeded to keep that to a minimum.
+recommended to keep that to a minimum.
 
 So say we have a `todos` namespace, an `add` reducer and a `todos` model.
 Outside the model they're called by `send('todos:add')` and
@@ -259,7 +259,7 @@ app.model({
 })
 ```
 
-In most cases using namespaces is beneficial, as having clear boundries makes
+In most cases using namespaces is beneficial, as having clear boundaries makes
 it easier to follow logic. But sometimes you need to call `actions` that
 operate over multiple domains (such as a "logout" `action`), or have a
 `subscription` that might trigger multiple `reducers` (such as a `websocket`
@@ -587,7 +587,7 @@ else document.body.appendChild(app.start())
 ```
 
 #### Rehydration
-Now that your application is succesfully rendering in Node, the next step would
+Now that your application is successfully rendering in Node, the next step would
 be to make it load a JavaScript bundle once has loaded the HTML. To do this we
 will use a technique called _rehydration_.
 
@@ -808,7 +808,7 @@ Out of the box `choo` only supports runtimes which support:
 
 This does not include Safari 9 or any version of IE. If support for these
 platforms is required you will have to provide some sort of transform that
-makes this functionalty available in older browsers.  The test suite uses
+makes this functionality available in older browsers.  The test suite uses
 [es2020](https://github.com/yoshuawuyts/es2020) as a global transform, but
 anything else which might satisfy this requirement is fair game.
 

--- a/examples/http/client.js
+++ b/examples/http/client.js
@@ -2,7 +2,26 @@ const choo = require('../../')
 
 const mainView = require('./views/main')
 
-const app = choo()
+const app = choo({
+  onError: function (err, state, createSend) {
+    console.groupCollapsed(`Error: ${err.message}`)
+    console.error(err)
+    console.groupEnd()
+    const send = createSend('onError: ')
+    send('app:error', err)
+  },
+  onAction: function (action, state, name, caller, createSend) {
+    console.groupCollapsed(`Action: ${caller} -> ${name}`)
+    console.log(action)
+    console.groupEnd()
+  },
+  onState: function (action, state, prev, createSend) {
+    console.groupCollapsed('State')
+    console.log(prev)
+    console.log(state)
+    console.groupEnd()
+  }
+})
 
 app.model(require('./models/error'))
 app.model(require('./models/api'))

--- a/examples/http/models/api.js
+++ b/examples/http/models/api.js
@@ -6,26 +6,26 @@ module.exports = {
     title: 'Button pushing machine 3000'
   },
   reducers: {
-    set: (action, state) => ({ 'title': action.payload })
+    set: (action, state) => ({ 'title': action.data })
   },
   effects: {
-    good: (action, state, send) => request('/good', send),
-    bad: (action, state, send) => request('/bad', send)
+    good: function (action, state, send, done) {
+      request('/good', send, done)
+    },
+    bad: (action, state, send, done) => request('/bad', send, done)
   }
 }
 
-function request (uri, send, state) {
+function request (uri, send, done) {
   http(uri, { json: true }, function (err, res, body) {
-    if (err) return send('app:error', { payload: 'HTTP error' })
+    if (err) return done(new Error('HTTP error'))
     if (res.statusCode !== 200) {
       const message = (body && body.message)
         ? body.message
         : 'unknown server error'
-      return send('app:error', { payload: message })
+      return done(new Error(message))
     }
-    if (!body) {
-      return send('app:error', { payload: 'fatal: no body received' })
-    }
-    send('api:set', { payload: body.message || body.title })
+    if (!body) return done(new Error('fatal: no body received'))
+    send('api:set', { data: body.message || body.title }, done)
   })
 }

--- a/examples/http/models/error.js
+++ b/examples/http/models/error.js
@@ -10,34 +10,43 @@ const ERROR_TIMEOUT = 1000
 module.exports = {
   namespace: 'app',
   state: {
-    error: [],
-    errorTimeDone: null,
+    errors: [],
+    errorTimeDone: 0,
     triggerTime: null
   },
   reducers: {
-    error: function (action, state) {
-      const now = Date.now()
-      const timeDone = state.errorTimeDone
-      const newTimestamp = (timeDone && timeDone >= now)
-        ? timeDone + ERROR_TIMEOUT
-        : now + ERROR_TIMEOUT
-
+    setError: function (action, state) {
       return {
-        error: state.error.concat(action.payload),
-        errorTimeDone: newTimestamp
+        errors: state.errors.concat(action.message),
+        errorTimeDone: action.errorTimeDone
       }
     },
-    'error:delete': function (action, state) {
-      state.error.shift()
-      return { error: state.error }
+    'delError': function (action, state) {
+      state.errors.shift()
+      return { errors: state.errors }
     }
   },
   effects: {
-    error: function (action, state, send) {
-      const timeout = state.errorTimeDone - Date.now()
-      setTimeout(function () {
-        send('app:error:delete')
-      }, timeout)
+    error: function (err, state, send, done) {
+      const timeDone = state.errorTimeDone
+      const now = Date.now()
+
+      const timeStamp = (timeDone && timeDone >= now)
+        ? timeDone + ERROR_TIMEOUT
+        : now + ERROR_TIMEOUT
+
+      const timeout = timeStamp - now
+
+      const errAction = {
+        message: err.message,
+        errorTimeDone: timeStamp
+      }
+      send('app:setError', errAction, function (err) {
+        if (err) return done(err)
+        setTimeout(function () {
+          send('app:delError', done)
+        }, timeout)
+      })
     }
   }
 }

--- a/examples/http/views/main.js
+++ b/examples/http/views/main.js
@@ -1,7 +1,7 @@
 const html = require('../../../html')
 
 module.exports = function (params, state, send) {
-  const error = state.app.error[0]
+  const error = state.app.errors[0]
   const title = state.api.title
   return html`
     <section>

--- a/examples/http/views/main.js
+++ b/examples/http/views/main.js
@@ -1,9 +1,9 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
   const error = state.app.error[0]
   const title = state.api.title
-  return choo.view`
+  return html`
     <section>
       <h1>${title}</h1>
       <h2>Latest error: ${error}</h2>

--- a/examples/mailbox/client.js
+++ b/examples/mailbox/client.js
@@ -2,7 +2,6 @@ const choo = require('../../')
 const sf = require('sheetify')
 
 sf('css-wipe/dest/bundle')
-sf('tachyons')
 
 const app = choo()
 

--- a/examples/mailbox/elements/email-list.js
+++ b/examples/mailbox/elements/email-list.js
@@ -1,10 +1,10 @@
 const dateformat = require('dateformat')
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
   const mailbox = params.mailbox
   const messages = state[mailbox].messages
-  return choo.view`
+  return html`
     <div>
       <div class="db cf w-100">
         <div class="fl mb3 w-25 mt0 b">Date</th>
@@ -20,7 +20,7 @@ module.exports = function (params, state, send) {
 }
 
 function createMessage (message, mailbox) {
-  return choo.view`
+  return html`
     <div class="db cf w-100">
       <a href="${'/' + mailbox + '/' + message.id}">
         <div class="fl mb3 w-25 f6 link">

--- a/examples/mailbox/elements/email.js
+++ b/examples/mailbox/elements/email.js
@@ -1,4 +1,4 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
   const mailbox = params.mailbox
@@ -8,7 +8,7 @@ module.exports = function (params, state, send) {
     return String(msg.id) === message
   })[0]
 
-  return choo.view`
+  return html`
     <div>
       ${email ? createEmail(email) : 'error: no email found'}
     </div
@@ -16,7 +16,7 @@ module.exports = function (params, state, send) {
 }
 
 function createEmail (message) {
-  return choo.view`
+  return html`
     <div class="mail">
       <dl>
         <dt>From</dt>

--- a/examples/mailbox/elements/empty-mailbox.js
+++ b/examples/mailbox/elements/empty-mailbox.js
@@ -1,7 +1,7 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
-  return choo.view`
+  return html`
     <section>
       <p>Select a mailbox</p>
     </section>

--- a/examples/mailbox/elements/mailbox.js
+++ b/examples/mailbox/elements/mailbox.js
@@ -1,5 +1,5 @@
 const dateformat = require('dateformat')
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function () {
   return function (params, state, send) {
@@ -12,7 +12,7 @@ module.exports = function () {
         return String(msg.id) === message
       })[0]
 
-      return choo.view`
+      return html`
         <section class="fl mt4 w-80 db">
           <div>
             ${createHeader()}
@@ -26,7 +26,7 @@ module.exports = function () {
         </section>
       `
     } else {
-      return choo.view`
+      return html`
         <section class="fl mt4 w-80 db">
           ${createHeader()}
           ${messages.map(function (msg) {
@@ -39,7 +39,7 @@ module.exports = function () {
 }
 
 function createHeader () {
-  return choo.view`
+  return html`
     <div class="db cf w-100">
       <div class="fl mb3 w-25 mt0 b">Date</th>
       <div class="fl mb3 w-25 mt0 b">Subject</th>
@@ -50,7 +50,7 @@ function createHeader () {
 }
 
 function createMessage (message, mailbox) {
-  return choo.view`
+  return html`
     <div class="db cf w-100">
       <a href="${'/' + mailbox + '/' + message.id}">
         <div class="fl mb3 w-25 f6 link">
@@ -65,7 +65,7 @@ function createMessage (message, mailbox) {
 }
 
 function createEmail (message) {
-  return choo.view`
+  return html`
     <div class="mail">
       <dl>
         <dt>From</dt>

--- a/examples/mailbox/elements/nav.js
+++ b/examples/mailbox/elements/nav.js
@@ -1,9 +1,9 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 const mailboxes = [ 'inbox', 'spam', 'sent' ]
 
 module.exports = function (params, state, send) {
-  return choo.view`
+  return html`
     <aside class="fl mt4 w-20 db">
       <ul>
         <li>
@@ -19,7 +19,7 @@ module.exports = function (params, state, send) {
 }
 
 function createLi (mailbox, messages) {
-  return choo.view`
+  return html`
     <li class="mt4 f6">
       <a href="/${mailbox}">
         ${mailbox.charAt(0).toUpperCase() + mailbox.slice(1)}

--- a/examples/mailbox/elements/pathname.js
+++ b/examples/mailbox/elements/pathname.js
@@ -1,9 +1,9 @@
 const pathname = require('pathname-match')
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
   const location = state.app.location
-  return choo.view`
+  return html`
     <span class="fl mt4 w-100 f4 b">
       URL: ${pathname(location) || '/'}
     </span>

--- a/examples/mailbox/package.json
+++ b/examples/mailbox/package.json
@@ -6,16 +6,18 @@
   "scripts": {
     "start": "NODE_ENV=development node server.js"
   },
-  "browserify": {
-    "transform": [
-      "sheetify/transform"
-    ]
-  },
   "author": "Yoshua Wuyts <i@yoshuawuyts.com>",
   "license": "ISC",
   "dependencies": {
     "css-wipe": "^4.2.1",
     "dateformat": "^1.0.12",
     "tachyons": "^4.0.0-beta.33"
+  },
+  "devDependencies": {
+    "bankai": "^2.0.5",
+    "browserify": "^13.0.1",
+    "insert-css": "^0.2.0",
+    "server-router": "^2.1.0",
+    "sheetify": "^5.0.3"
   }
 }

--- a/examples/mailbox/views/email.js
+++ b/examples/mailbox/views/email.js
@@ -1,4 +1,4 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 const emailList = require('../elements/email-list')
 const pathname = require('../elements/pathname')
@@ -6,7 +6,7 @@ const email = require('../elements/email')
 const nav = require('../elements/nav')
 
 module.exports = function (params, state, send) {
-  return choo.view`
+  return html`
     <main class="mw5 mw7-ns center cf">
       ${pathname(params, state, send)}
       ${nav(params, state, send)}

--- a/examples/mailbox/views/empty.js
+++ b/examples/mailbox/views/empty.js
@@ -1,11 +1,11 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 const empty = require('../elements/empty-mailbox')
 const pathname = require('../elements/pathname')
 const nav = require('../elements/nav')
 
 module.exports = function (params, state, send) {
-  return choo.view`
+  return html`
     <main class="mw5 mw7-ns center cf">
       ${pathname(params, state, send)}
       ${nav(params, state, send)}

--- a/examples/mailbox/views/mailbox.js
+++ b/examples/mailbox/views/mailbox.js
@@ -1,11 +1,11 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 const emailList = require('../elements/email-list')
 const pathname = require('../elements/pathname')
 const nav = require('../elements/nav')
 
 module.exports = function (params, state, send) {
-  return choo.view`
+  return html`
     <main class="mw5 mw7-ns center cf">
       ${pathname(params, state, send)}
       ${nav(params, state, send)}

--- a/examples/server-rendering/views/main.js
+++ b/examples/server-rendering/views/main.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
   const serverMessage = state.message.server
@@ -8,7 +8,7 @@ module.exports = function (params, state, send) {
   assert.equal(typeof serverMessage, 'string', 'server should be a string')
   assert.equal(typeof clientMessage, 'string', 'client should be a string')
 
-  return choo.view`
+  return html`
     <section id="app-root">
       <h1>server message: ${serverMessage}</h1>
       <h1>client message: ${clientMessage}</h1>

--- a/examples/sse/client.js
+++ b/examples/sse/client.js
@@ -1,4 +1,5 @@
 const choo = require('../../')
+const html = require('../../html')
 
 const app = choo()
 app.model(createModel())
@@ -10,7 +11,7 @@ const tree = app.start()
 document.body.appendChild(tree)
 
 function mainView (params, state, send) {
-  return choo.view`
+  return html`
     <div>${state.logger.msg}</div>
   `
 }

--- a/examples/sse/views/main.js
+++ b/examples/sse/views/main.js
@@ -1,9 +1,9 @@
-const choo = require('../../../')
+const html = require('../../../html')
 
 module.exports = function (params, state, send) {
   const error = state.app.error[0]
   const title = state.api.title
-  return choo.view`
+  return html`
     <section>
       <h1>${title}</h1>
       <h2>Latest error: ${error}</h2>

--- a/examples/title/client.js
+++ b/examples/title/client.js
@@ -1,4 +1,5 @@
 const choo = require('../../')
+const html = require('../../html')
 
 const app = choo()
 app.model({
@@ -15,7 +16,7 @@ app.model({
 })
 
 const mainView = (params, state, send) => {
-  return choo.view`
+  return html`
     <main class="app">
       <h1>${state.input.title}</h1>
       <label>Set the title</label>

--- a/examples/title/package.json
+++ b/examples/title/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "title",
+  "version": "1.0.0",
+  "description": "",
+  "main": "client.js",
+  "scripts": {
+    "start": "budo client.js -p 8080"
+  },
+  "keywords": [],
+  "author": "Yoshua Wuyts <i@yoshuawuyts.com>",
+  "license": "ISC",
+  "dependencies": {
+    "budo": "^8.3.0"
+  }
+}

--- a/html.js
+++ b/html.js
@@ -1,0 +1,1 @@
+module.exports = require('yo-yo')

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const assert = require('assert')
 const xtend = require('xtend')
 const yo = require('yo-yo')
 
-choo.view = yo
 module.exports = choo
 
 // framework for creating sturdy web applications

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function choo (opts) {
     const tree = _router(route, state, function () {
       assert.fail('choo: send() cannot be called from Node')
     })
-    return tree.toString()
+    return tree.outerHTML || tree.toString()
   }
 
   // start the application

--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ const document = require('global/document')
 const href = require('sheet-router/href')
 const hash = require('sheet-router/hash')
 const hashMatch = require('hash-match')
-const sendAction = require('send-action')
-const mutate = require('xtend/mutable')
+const barracks = require('barracks')
 const assert = require('assert')
 const xtend = require('xtend')
 const yo = require('yo-yo')
@@ -14,8 +13,11 @@ module.exports = choo
 
 // framework for creating sturdy web applications
 // null -> fn
-function choo () {
-  const _models = []
+function choo (opts) {
+  opts = opts || {}
+
+  const _store = barracks(xtend(opts, { onState: render }))
+  var _rootNode = null
   var _router = null
 
   start.toString = toString
@@ -28,153 +30,55 @@ function choo () {
   // render the application to a string
   // (str, obj) -> str
   function toString (route, serverState) {
-    const initialState = {}
-    const nsState = {}
-
-    _models.forEach(function (model) {
-      const ns = model.namespace
-      if (ns) {
-        if (!nsState[ns]) nsState[ns] = {}
-        apply(ns, model.state, nsState)
-        nsState[ns] = xtend(nsState[ns], serverState[ns])
-      } else {
-        apply(model.namespace, model.state, initialState)
-      }
-    })
-
-    const state = xtend(initialState, xtend(serverState, nsState))
+    serverState = serverState || {}
+    assert.equal(typeof route, 'string', 'choo.app.toString: route must be a string')
+    assert.equal(typeof serverState, 'object', 'choo.app.toString: serverState must be an object')
+    _store.start({ noSubscriptions: true, noReducers: true, noEffects: true })
+    const state = _store.state({ state: serverState })
     const tree = _router(route, state, function () {
-      throw new Error('send() cannot be called on the server')
+      assert.fail('choo: send() cannot be called from Node')
     })
-
     return tree.toString()
   }
 
   // start the application
   // (str?, obj?) -> DOMNode
-  function start (rootId, opts) {
-    if (!opts && typeof rootId !== 'string') {
-      opts = rootId
-      rootId = null
+  function start (selector, startOpts) {
+    if (!startOpts && typeof selector !== 'string') {
+      startOpts = selector
+      selector = null
     }
-    opts = opts || {}
-    const name = opts.name || 'choo'
-    const initialState = {}
-    const reducers = {}
-    const effects = {}
+    startOpts = startOpts || {}
 
-    _models.push(appInit(opts))
-    _models.forEach(function (model) {
-      if (model.state) apply(model.namespace, model.state, initialState)
-      if (model.reducers) apply(model.namespace, model.reducers, reducers)
-      if (model.effects) apply(model.namespace, model.effects, effects)
-    })
+    _store.model(appInit(startOpts))
+    const createSend = _store.start(startOpts)
+    const send = createSend('view', true)
+    const state = _store.state()
 
-    // send() is used to trigger actions inside
-    // views, effects and subscriptions
-    const send = sendAction({
-      onaction: handleAction,
-      onchange: onchange,
-      state: initialState
-    })
-
-    // subscriptions are loaded after sendAction() is called
-    // because they both need access to send() and can't
-    // react to actions (read-only) - also wait on DOM to
-    // be loaded
-    document.addEventListener('DOMContentLoaded', function () {
-      _models.forEach(function (model) {
-        if (model.subscriptions) {
-          assert.ok(Array.isArray(model.subscriptions), 'subs must be an arr')
-          model.subscriptions.forEach(function (sub) {
-            sub(send)
-          })
-        }
-      })
-    })
-
-    // If an id is provided, the application will rehydrate
-    // on the node. If no id is provided it will return
-    // a tree that's ready to be appended to the DOM.
-    //
-    // The rootId is determined to find the application root
-    // on update. Since the DOM nodes change between updates,
-    // we must call document.querySelector() to find the root.
-    // Use different names when loading multiple choo applications
-    // on the same page
-    if (rootId) {
-      document.addEventListener('DOMContentLoaded', function (event) {
-        rootId = rootId.replace(/^#/, '')
-
-        const oldTree = document.querySelector('#' + rootId)
-        assert.ok(oldTree, 'could not find node #' + rootId)
-
-        const newTree = _router(send.state().app.location, send.state(), send)
-
-        yo.update(oldTree, newTree)
-      })
-    } else {
-      rootId = name + '-root'
-      const tree = _router(send.state().app.location, send.state(), send)
-      tree.setAttribute('id', rootId)
+    if (!selector) {
+      const tree = _router(state.app.location, state, send)
+      _rootNode = tree
       return tree
+    } else {
+      document.addEventListener('DOMContentLoaded', function (event) {
+        const oldTree = document.querySelector(selector)
+        assert.ok(oldTree, 'could not query selector: ' + selector)
+        const newTree = _router(state.app.location, state, send)
+        _rootNode = yo.update(oldTree, newTree)
+      })
     }
+  }
 
-    // handle an action by either reducers, effects
-    // or both - return the new state when done
-    // (obj, obj, fn) -> obj
-    function handleAction (action, state, send) {
-      var reducersCalled = false
-      var effectsCalled = false
-      const newState = xtend(state)
+  // update the DOM after every state mutation
+  // (obj, obj, obj, str, fn) -> null
+  function render (action, state, prev, name, createSend) {
+    if (opts.onState) opts.onState(action, state, prev, name, createSend)
+    if (state === prev) return
 
-      // validate if a namespace exists. Namespaces
-      // are delimited by the first ':'. Perhaps
-      // we'll allow recursive namespaces in the
-      // future - who knows
-      if (/:/.test(action.type)) {
-        const arr = action.type.split(':')
-        var ns = arr.shift()
-        action.type = arr.join(':')
-      }
-
-      const _reducers = ns ? reducers[ns] : reducers
-      if (_reducers && _reducers[action.type]) {
-        if (ns) {
-          const reducedState = _reducers[action.type](action, state[ns])
-          if (!newState[ns]) newState[ns] = {}
-          mutate(newState[ns], xtend(state[ns], reducedState))
-        } else {
-          mutate(newState, reducers[action.type](action, state))
-        }
-        reducersCalled = true
-      }
-
-      const _effects = ns ? effects[ns] : effects
-      if (_effects && _effects[action.type]) {
-        if (ns) _effects[action.type](action, state[ns], send)
-        else _effects[action.type](action, state, send)
-        effectsCalled = true
-      }
-
-      if (!reducersCalled && !effectsCalled) {
-        throw new Error('Could not find action ' + action.type)
-      }
-
-      // allows (newState === oldState) checks
-      return (reducersCalled) ? newState : state
-    }
-
-    // update the DOM after every state mutation
-    // (obj, obj) -> null
-    function onchange (action, newState, oldState) {
-      if (newState === oldState) return
-      const oldTree = document.querySelector('#' + rootId)
-      assert.ok(oldTree, "Could not find DOM node '#" + rootId + "' to update")
-      const newTree = _router(newState.app.location, newState, send, oldState)
-      newTree.setAttribute('id', rootId)
-      yo.update(oldTree, newTree)
-    }
+    // note(yw): only here till sheet-router supports custom constructors
+    const send = createSend('view', true)
+    const newTree = _router(state.app.location, state, send, prev)
+    _rootNode = yo.update(_rootNode, newTree)
   }
 
   // register all routes on the router
@@ -187,68 +91,48 @@ function choo () {
   // create a new model
   // (str?, obj) -> null
   function model (model) {
-    _models.push(model)
+    _store.model(model)
   }
 }
 
 // initial application state model
 // obj -> obj
 function appInit (opts) {
-  const initialLocation = (opts.hash === true)
-    ? hashMatch(document.location.hash)
-    : document.location.href
-
-  const model = {
-    namespace: 'app',
-    state: { location: initialLocation },
-    subscriptions: [],
-    reducers: {
-      // handle href links
-      location: function setLocation (action, state) {
-        return {
-          location: action.location.replace(/#.*/, '')
-        }
-      }
+  const loc = document.location
+  const state = { location: (opts.hash) ? hashMatch(loc.hash) : loc.href }
+  const reducers = {
+    location: function setLocation (action, state) {
+      return { location: action.location.replace(/#.*/, '') }
     }
   }
-
   // if hash routing explicitly enabled, subscribe to it
+  const subs = {}
   if (opts.hash === true) {
     pushLocationSub(function (navigate) {
       hash(function (fragment) {
         navigate(hashMatch(fragment))
       })
-    })
-  // otherwise, subscribe to HTML5 history API
+    }, 'handleHash', subs)
   } else {
-    if (opts.history !== false) pushLocationSub(history)
-    // enable catching <a href=""></a> links
-    if (opts.href !== false) pushLocationSub(href)
+    if (opts.history !== false) pushLocationSub(history, 'setLocation', subs)
+    if (opts.href !== false) pushLocationSub(href, 'handleHref', subs)
   }
 
-  return model
+  return {
+    namespace: 'app',
+    subscriptions: subs,
+    reducers: reducers,
+    state: state
+  }
 
   // create a new subscription that modifies
   // 'app:location' and push it to be loaded
-  // fn -> null
-  function pushLocationSub (cb) {
-    model.subscriptions.push(function (send) {
-      cb(function (href) {
-        send('app:location', { location: href })
+  // (fn, obj) -> null
+  function pushLocationSub (cb, key, model) {
+    model[key] = function (send, done) {
+      cb(function navigate (href) {
+        send('app:location', { location: href }, done)
       })
-    })
+    }
   }
-}
-
-// compose an object conditionally
-// optionally contains a namespace
-// which is used to nest properties.
-// (str, obj, obj) -> null
-function apply (ns, source, target) {
-  Object.keys(source).forEach(function (key) {
-    if (ns) {
-      if (!target[ns]) target[ns] = {}
-      target[ns][key] = source[key]
-    } else target[key] = source[key]
-  })
 }

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "barracks": "^7.0.3",
     "global": "^4.3.0",
     "hash-match": "^1.0.2",
-    "send-action": "^2.0.2",
     "sheet-router": "^3.1.0",
     "xhr": "^2.2.0",
     "xtend": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev -i xhr",
+    "test:electron": "browserify tests/**/*.js -t es2020 | tape-run",
     "test:server": "standard && npm run deps && NODE_ENV=test node tests/server/*",
     "test:server:cov": "standard && npm run deps && NODE_ENV=test istanbul cover tests/server/*",
     "test:browser": "standard && npm run deps && NODE_ENV=test zuul tests/browser/*",
@@ -35,7 +36,6 @@
   "devDependencies": {
     "bankai": "^2.0.2",
     "browserify": "^13.0.1",
-    "browserify-istanbul": "^2.0.0",
     "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.5.1",
     "es2020": "^1.0.1",
@@ -47,6 +47,7 @@
     "standard": "^7.1.0",
     "tachyons": "^4.0.0-beta.19",
     "tape": "^4.5.1",
+    "tape-run": "~2.1.4",
     "zuul": "toddself/zuul"
   }
 }

--- a/tests/browser/basic.js
+++ b/tests/browser/basic.js
@@ -1,5 +1,6 @@
 const tape = require('tape')
 const choo = require('../../')
+const view = require('../../html')
 
 tape('should render on the client', function (t) {
   t.test('state should not be mutable', function (t) {
@@ -50,7 +51,7 @@ tape('should render on the client', function (t) {
         ++loop
         asserts[loop] && asserts[loop](state.test)
         setTimeout(() => triggers[loop] && triggers[loop](send), 5)
-        return choo.view`<div><span class="test">${state.foo}:${state.beep}</span></div>`
+        return view`<div><span class="test">${state.foo}:${state.beep}</span></div>`
       })
     ])
 

--- a/tests/browser/basic.js
+++ b/tests/browser/basic.js
@@ -25,8 +25,8 @@ tape('should render on the client', function (t) {
         }
       },
       effects: {
-        'triggers-reducers': (action, state, send) => {
-          send('test:mutate-on-return', {beep: 'barp'})
+        'triggers-reducers': (action, state, send, done) => {
+          send('test:mutate-on-return', {beep: 'barp'}, done)
         }
       }
     })

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -1,5 +1,6 @@
 const tape = require('tape')
 const choo = require('../../')
+const view = require('../../html')
 
 tape('should render on the server', function (t) {
   t.test('should render a static response', function (t) {
@@ -7,7 +8,7 @@ tape('should render on the server', function (t) {
 
     const app = choo()
     app.router((route) => [
-      route('/', () => choo.view`<h1>Hello Tokyo!</h1>`)
+      route('/', () => view`<h1>Hello Tokyo!</h1>`)
     ])
 
     const html = app.toString('/')
@@ -21,7 +22,7 @@ tape('should render on the server', function (t) {
     const app = choo()
     app.router((route) => [
       route('/', function (params, state) {
-        return choo.view`<h1>meow meow ${state.message}</h1>`
+        return view`<h1>meow meow ${state.message}</h1>`
       })
     ])
 
@@ -37,7 +38,7 @@ tape('should render on the server', function (t) {
     app.model({ state: { bin: 'baz', beep: 'boop' } })
     app.router((route) => [
       route('/', function (params, state) {
-        return choo.view`<h1>${state.foo} ${state.bin} ${state.beep}</h1>`
+        return view`<h1>${state.foo} ${state.bin} ${state.beep}</h1>`
       })
     ])
 
@@ -57,7 +58,7 @@ tape('should render on the server', function (t) {
     })
     app.router((route) => [
       route('/', function (params, state) {
-        return choo.view`
+        return view`
           <h1>${state.hello.foo} ${state.hello.bin} ${state.hello.beep}</h1>
         `
       })

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -98,7 +98,7 @@ tape('should render on the server', function (t) {
       })
     ])
 
-    const msg = /send\(\) cannot be called on the server/
+    const msg = /send\(\) cannot be called/
     t.throws(app.toString.bind(null, '/', { message: 'nyan!' }), msg)
   })
 })


### PR DESCRIPTION
This lays the necessary groundwork to use Electron as the primary test runner via [tape-run](https://github.com/juliangruber/tape-run). Sauce Labs is great as a regression defense and the fancy table badge. Electron is a better primary test runner because it can run *all* the tests and get a true global coverage number. It can be run headless but still has a real DOM.  