### PR TITLE
only run the tests when trying to make a new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [Errors](#errors)
 - [FAQ](#faq)
 - [Installation](#installation)
+- [Contributing](#contributing)
 - [See Also](#see-also)
 - [License](#license)
 
@@ -839,6 +840,13 @@ Sure.
 ```sh
 $ npm install choo
 ```
+
+## Contributing
+Browser tests can be run with the right credentials via the `npm run test:browser`
+command.  This will be run automatically when `npm version` is executed.
+
+You may skip the tests by providing `SKIP_TEST=true` when running the version
+command.
 
 ## See Also
 - [budo](https://github.com/mattdesl/budo) - quick prototyping tool for

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "test:server:cov": "standard && npm run deps && NODE_ENV=test istanbul cover tests/server/*",
     "test:browser": "standard && npm run deps && NODE_ENV=test zuul tests/browser/*",
     "test:browser:local": "standard && npm run deps && NODE_ENV=test zuul --local 8080 -- tests/browser/*",
-    "test:cov": "npm run test:server:cov && npm run test:browser",
-    "test": "npm run test:server && npm run test:browser"
+    "test:cov": "npm run test:server:cov",
+    "preversion": "if [ ! -z $SKIP_TEST ]; then npm run test:browser; fi",
+    "test": "npm run test:server"
   },
   "repository": "yoshuawuyts/choo",
   "keywords": [


### PR DESCRIPTION
So!

I always forget that `prepublish` runs on `install` when you run install from a cloned repo. Which means anyone doing an `npm install` in choo to do dev works would have to run the tests. 

I disagree with this concept, but that [is a very well traveled road](https://github.com/npm/npm/issues/3059) so instead of running on publish, it runs when you try to generate a new version with `npm version`.

Not the best solution, but definitely better than forcing devs to sit through a test in order to work on choo.

You  CAN skip the test with `SKIP_TEST=true npm version [patch|minor|major]`.