### PR TITLE
Change view arguments

### DIFF
--- a/examples/http/views/main.js
+++ b/examples/http/views/main.js
@@ -1,6 +1,6 @@
 const html = require('../../../html')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   const error = state.app.errors[0]
   const title = state.api.title
   return html`

--- a/examples/mailbox/elements/email-list.js
+++ b/examples/mailbox/elements/email-list.js
@@ -1,7 +1,8 @@
 const dateformat = require('dateformat')
 const html = require('../../../html')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
+  const params = state.params
   const mailbox = params.mailbox
   const messages = state[mailbox].messages
   return html`

--- a/examples/mailbox/elements/email.js
+++ b/examples/mailbox/elements/email.js
@@ -1,6 +1,7 @@
 const html = require('../../../html')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
+  const params = state.params
   const mailbox = params.mailbox
   const message = params.message
 

--- a/examples/mailbox/elements/empty-mailbox.js
+++ b/examples/mailbox/elements/empty-mailbox.js
@@ -1,6 +1,6 @@
 const html = require('../../../html')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   return html`
     <section>
       <p>Select a mailbox</p>

--- a/examples/mailbox/elements/mailbox.js
+++ b/examples/mailbox/elements/mailbox.js
@@ -2,7 +2,8 @@ const dateformat = require('dateformat')
 const html = require('../../../html')
 
 module.exports = function () {
-  return function (params, state, send) {
+  return function (state, prev, send) {
+    const params = state.params
     const mailbox = params.mailbox
     const message = params.message
     const messages = state[mailbox].messages

--- a/examples/mailbox/elements/nav.js
+++ b/examples/mailbox/elements/nav.js
@@ -2,7 +2,7 @@ const html = require('../../../html')
 
 const mailboxes = [ 'inbox', 'spam', 'sent' ]
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   return html`
     <aside class="fl mt4 w-20 db">
       <ul>

--- a/examples/mailbox/elements/pathname.js
+++ b/examples/mailbox/elements/pathname.js
@@ -1,8 +1,8 @@
 const pathname = require('pathname-match')
 const html = require('../../../html')
 
-module.exports = function (params, state, send) {
-  const location = state.app.location
+module.exports = function (state, prev, send) {
+  const location = state.location.pathname
   return html`
     <span class="fl mt4 w-100 f4 b">
       URL: ${pathname(location) || '/'}

--- a/examples/mailbox/views/email.js
+++ b/examples/mailbox/views/email.js
@@ -5,14 +5,14 @@ const pathname = require('../elements/pathname')
 const email = require('../elements/email')
 const nav = require('../elements/nav')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   return html`
     <main class="mw5 mw7-ns center cf">
-      ${pathname(params, state, send)}
-      ${nav(params, state, send)}
+      ${pathname(state, prev, send)}
+      ${nav(state, prev, send)}
       <section class="fl mt4 w-80 db">
-        ${emailList(params, state, send)}
-        ${email(params, state, send)}
+        ${emailList(state, prev, send)}
+        ${email(state, prev, send)}
       </section>
     </main>
   `

--- a/examples/mailbox/views/empty.js
+++ b/examples/mailbox/views/empty.js
@@ -4,12 +4,12 @@ const empty = require('../elements/empty-mailbox')
 const pathname = require('../elements/pathname')
 const nav = require('../elements/nav')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   return html`
     <main class="mw5 mw7-ns center cf">
-      ${pathname(params, state, send)}
-      ${nav(params, state, send)}
-      ${empty(params, state, send)}
+      ${pathname(state, prev, send)}
+      ${nav(state, prev, send)}
+      ${empty(state, prev, send)}
     </main>
   `
 }

--- a/examples/mailbox/views/mailbox.js
+++ b/examples/mailbox/views/mailbox.js
@@ -4,13 +4,13 @@ const emailList = require('../elements/email-list')
 const pathname = require('../elements/pathname')
 const nav = require('../elements/nav')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   return html`
     <main class="mw5 mw7-ns center cf">
-      ${pathname(params, state, send)}
-      ${nav(params, state, send)}
+      ${pathname(state, prev, send)}
+      ${nav(state, prev, send)}
       <section class="fl mt4 w-80 db">
-        ${emailList(params, state, send)}
+        ${emailList(state, prev, send)}
       </section>
     </main>
   `

--- a/examples/server-rendering/views/main.js
+++ b/examples/server-rendering/views/main.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const html = require('../../../html')
 
-module.exports = function (params, state, send) {
+module.exports = function (state, prev, send) {
   const serverMessage = state.message.server
   const clientMessage = state.message.client
 

--- a/examples/title/client.js
+++ b/examples/title/client.js
@@ -15,7 +15,7 @@ app.model({
   }
 })
 
-const mainView = (params, state, send) => {
+const mainView = (state, prev, send) => {
   return html`
     <main class="app">
       <h1>${state.input.title}</h1>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sheet-router": "^3.1.0",
     "xhr": "^2.2.0",
     "xtend": "^4.0.1",
-    "yo-yo": "^1.2.0"
+    "yo-yo": "^1.2.2"
   },
   "devDependencies": {
     "bankai": "^2.0.2",

--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -21,7 +21,7 @@ tape('should render on the server', function (t) {
 
     const app = choo()
     app.router((route) => [
-      route('/', function (params, state) {
+      route('/', function (state, prev, send) {
         return view`<h1>meow meow ${state.message}</h1>`
       })
     ])
@@ -37,7 +37,7 @@ tape('should render on the server', function (t) {
     const app = choo()
     app.model({ state: { bin: 'baz', beep: 'boop' } })
     app.router((route) => [
-      route('/', function (params, state) {
+      route('/', function (state, prev, send) {
         return view`<h1>${state.foo} ${state.bin} ${state.beep}</h1>`
       })
     ])
@@ -57,7 +57,7 @@ tape('should render on the server', function (t) {
       state: { bin: 'baz', beep: 'boop' }
     })
     app.router((route) => [
-      route('/', function (params, state) {
+      route('/', function (state, prev, send) {
         return view`
           <h1>${state.hello.foo} ${state.hello.bin} ${state.hello.beep}</h1>
         `
@@ -80,7 +80,7 @@ tape('should render on the server', function (t) {
 
     const app = choo()
     app.router((route) => [
-      route('/', function (params, state, send) {
+      route('/', function (state, prev, send) {
         send('hey!')
       })
     ])
@@ -93,7 +93,7 @@ tape('should render on the server', function (t) {
 
     const app = choo()
     app.router((route) => [
-      route('/', function (params, state, send) {
+      route('/', function (state, prev, send) {
         send('hey!')
       })
     ])


### PR DESCRIPTION
Relevant commit are 	d0788fc and a3bb4f3. Builds on top of #104 

- creates a named `send()` function for views; e.g. caller in `onAction` becomes the name of the view
- changes order of arguments as per #35 
- changes internal `app` namespace to `location` as per #82 

Needs testing and rebase obv, but this should provide a good idea of stuff