### PR TITLE
Use relative links to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@
 - __very cute:__ choo choo!
 
 ## Demos
-- [Input example](https://github.com/yoshuawuyts/choo/tree/master/examples/title)
+- [Input example](examples/title/)
   ([requirebin](http://requirebin.com/?gist=e589473373b3100a6ace29f7bbee3186))
 - [HTTP effects example](https://fork-fang.hyperdev.space/)
   ([hyperdev](https://hyperdev.com/#!/project/fork-fang))
-- [Mailbox routing example](https://github.com/yoshuawuyts/choo/tree/master/examples/mailbox)
+- [Mailbox routing example](examples/mailbox/)
   (@examples directory)
 - [TodoMVC](http://shuheikagawa.com/todomvc-choo/)
   ([github](https://github.com/shuhei/todomvc-choo))


### PR DESCRIPTION
Cleans up the links to example directories by making them relative.

PS: Someone should look into hosting the mailbox example online so we can give that a real link! I might do it myself later.