### PR TITLE
index: add raf guard

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const href = require('sheet-router/href')
 const hash = require('sheet-router/hash')
 const hashMatch = require('hash-match')
 const barracks = require('barracks')
+const nanoraf = require('nanoraf')
 const assert = require('assert')
 const xtend = require('xtend')
 const yo = require('yo-yo')
@@ -22,6 +23,7 @@ function choo (opts) {
   var _defaultRoute = null
   var _rootNode = null
   var _routes = null
+  var _frame = null
 
   start.toString = toString
   start.router = router
@@ -85,8 +87,13 @@ function choo (opts) {
       opts.onStateChange(data, state, prev, name, createSend)
     }
 
-    const newTree = _router(state.location.pathname, state, prev)
-    _rootNode = yo.update(_rootNode, newTree)
+    if (!_frame) {
+      _frame = nanoraf(function (state, prev) {
+        const newTree = _router(state.location.pathname, state, prev)
+        _rootNode = yo.update(_rootNode, newTree)
+      })
+    }
+    _frame(state, prev)
   }
 
   // register all routes on the router

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "document-ready": "~1.0.2",
     "global": "^4.3.0",
     "hash-match": "^1.0.2",
+    "nanoraf": "^2.0.0",
     "sheet-router": "^3.1.0",
     "xhr": "^2.2.0",
     "xtend": "^4.0.1",


### PR DESCRIPTION
Adds a `requestAnimationFrame` loop, so unbound state mutations don't thrash the UI thread. The more boring cousin to isolated mutable updates (which I might gist up soonish, perhaps). Means it'll only run on IE10+ without a shim attached on the `window` (e.g. < 1% browsers are affected).

Provides a 10000x perf improvement in some scenarios, or something like that.

Closes #99 #81. Thanks! :sparkles: