### PR TITLE
Add pathname-match dependency to mailbox example

### DIFF
--- a/examples/mailbox/package.json
+++ b/examples/mailbox/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "css-wipe": "^4.2.1",
     "dateformat": "^1.0.12",
+    "pathname-match": "^1.1.3",
     "tachyons": "^4.0.0-beta.33"
   },
   "devDependencies": {


### PR DESCRIPTION
The pathname-match module is being required in the pathname element, but wasn't actually included as a dependency.