### PR TITLE
script/build: add gz variant

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,6 +9,16 @@ usage () {
   printf "Usage: build-umd <argument>\n"
 }
 
+# use zopfli for better compression if available
+gzip () {
+  zopfli -h 2>/dev/null
+  if [ $? -eq 0 ]; then
+    zopfli "$1" -i1000 -c
+  else
+    gzip -c "$1"
+  fi
+}
+
 build_dev () {
   mkdir -p dist/
   NODE_ENV=development "$browserify" index.js \
@@ -35,6 +45,12 @@ build_min () {
     > dist/choo.min.js
 }
 
+build_gz () {
+  build_min
+  gzip dist/choo.min.js > dist/choo.min.js.gz
+  cp dist/choo.min.js.gz dist/choo.gz
+}
+
 # parse CLI flags
 while true; do
   case "$1" in
@@ -47,5 +63,6 @@ done
 case "$1" in
   d|dev) shift; build_dev "$@" ;;
   m|min) shift; build_min "$@" ;;
+  g|gzip) shift; build_gz "$@" ;;
   *) shift; build_min "$@" ;;
 esac


### PR DESCRIPTION
Because npmcdn is doing weird things with their gzip; guess we gotta upload the gzip variant ourselves too >.> https://npmcdn.com/choo@3.1.0/dist/