### PR TITLE
Update args in examples/vanilla to 3.0

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -13,13 +13,13 @@
                   count: 0
               },
               reducers: {
-                increment: (action, state) => ({count: state.count + 1}),
-                decrement: (action, state) => ({count: state.count - 1})
+                increment: (data, state) => ({count: state.count + 1}),
+                decrement: (data, state) => ({count: state.count - 1})
               }
             })
 
-            const mainView = (params, state, send) => {
-              return choo.view`
+            const mainView = (state, prev, send) => {
+              return html`
                 <main class="app">
                   <h1>Counter example</h1>
                   <div>


### PR DESCRIPTION
Note that this example **does not work** until #160 is resolved, but at least it will now show the latest params. Thanks for pointing it out @maxogden! 