### PR TITLE
Use properly formatted assert() statement for send() on server

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function choo (opts) {
 
     function createSend () {
       return function send () {
-        assert.fail('choo: send() cannot be called from Node')
+        assert.ok(false, 'choo: send() cannot be called from Node')
       }
     }
   }


### PR DESCRIPTION
Addresses a problem noted in #171, where an improperly formatted `assert` call meant that `unassertify` didn’t remove the function when compiled.