### PR TITLE
build and test scripts use binaries on path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test": "npm run test:electron",
     "build:dev": "./scripts/build dev",
     "build:min": "./scripts/build min",
-    "prepublish": "npm run build:dev && npm run build:min"
+    "prepublish": "npm run build:dev && npm run build:min",
+    "instrument:discify": "./scripts/instrument discify",
+    "instrument:minified": "./scripts/instrument minified",
+    "instrument:gzip": "./scripts/instrument gzip"
   },
   "repository": "yoshuawuyts/choo",
   "keywords": [

--- a/scripts/build
+++ b/scripts/build
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-dirname=$(dirname "$(readlink -f "$0")")
-
-browserify="$dirname/../node_modules/.bin/browserify"
-uglify="$dirname/../node_modules/.bin/uglifyjs"
-
 usage () {
   printf "Usage: build-umd <argument>\n"
 }
@@ -21,7 +16,7 @@ gzip () {
 
 build_dev () {
   mkdir -p dist/
-  NODE_ENV=development "$browserify" index.js \
+  NODE_ENV=development browserify index.js \
     --standalone=choo \
     -t envify \
     -g yo-yoify \
@@ -31,7 +26,7 @@ build_dev () {
 
 build_min () {
   mkdir -p dist/
-  NODE_ENV=production "$browserify" index.js \
+  NODE_ENV=production browserify index.js \
     --standalone=choo \
     -t envify \
     -g unassertify \
@@ -41,7 +36,6 @@ build_min () {
     -t envify \
     -p bundle-collapser/plugin \
     | uglifyjs \
-    | "$uglify" \
     > dist/choo.min.js
 }
 

--- a/scripts/instrument
+++ b/scripts/instrument
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-dirname=$(dirname "$(readlink -f "$0")")
-
-browserify="$dirname/../node_modules/.bin/browserify"
-uglify="$dirname/../node_modules/.bin/uglifyjs"
-pretty_bytes="$dirname/../node_modules/.bin/pretty-bytes"
-gzip_size="$dirname/../node_modules/.bin/gzip-size"
-discify="$dirname/../node_modules/.bin/discify"
-
 usage () {
 cat << USAGE
 script/test-size
@@ -24,45 +16,45 @@ gzip () {
   if [ $? -eq 0 ]; then
     zopfli "$1" -i1000 -c | wc -c
   else
-    "$gzip_size" < "$1"
+    gzip-size < "$1"
   fi
 }
 
 gzip_size () {
   mkdir -p tmp/
-  "$browserify" index.js \
+  browserify index.js \
     -g unassertify \
     -g yo-yoify \
     -g es2020 \
     -g uglifyify \
     -p bundle-collapser/plugin \
-    | "$uglify" \
+    | uglifyjs \
     > tmp/bundle.min.js
 
-    gzip tmp/bundle.min.js | "$pretty_bytes"
+    gzip tmp/bundle.min.js | pretty-bytes
     rm -rf tmp/
 }
 
 min_size () {
-  "$browserify" index.js \
+  browserify index.js \
     -g unassertify \
     -g yo-yoify \
     -g es2020 \
     -g uglifyify \
     -p bundle-collapser/plugin \
-    | "$uglify" \
+    | uglifyjs \
     | wc -c \
-    | "$pretty_bytes"
+    | pretty-bytes
 }
 
 run_discify () {
-  "$browserify" index.js --full-paths \
+  browserify index.js --full-paths \
     -g unassertify \
     -g yo-yoify \
     -g es2020 \
     -g uglifyify \
-    | "$uglify" \
-    | "$discify" --open
+    | uglifyjs \
+    | discify --open
 }
 
 # set CLI flags

--- a/scripts/test
+++ b/scripts/test
@@ -3,43 +3,33 @@
 # setting exit because we're linting and need to exit on failure
 set -e
 
-dirname=$(dirname "$(readlink -f "$0")")
-
-dependency_check="$dirname/../node_modules/.bin/dependency-check"
-tape_istanbul="$dirname/../node_modules/.bin/tape-istanbul"
-browserify="$dirname/../node_modules/.bin/browserify"
-standard="$dirname/../node_modules/.bin/standard"
-tape_run="$dirname/../node_modules/.bin/tape-run"
-istanbul="$dirname/../node_modules/.bin/istanbul"
-zuul="$dirname/../node_modules/.bin/zuul"
-
 usage () {
   printf "Usage: test\n"
 }
 
 lint () {
-  "$standard"
+  standard
 }
 
 test_electron () {
   check_deps
   lint
-  "$browserify" tests/**/*.js \
+  browserify tests/**/*.js \
     -t es2020 \
     -p proxyquire-universal \
-      | "$tape_run"
+      | tape-run
 }
 
 test_cov () {
   check_deps
   lint
-  "$browserify" tests/**/*.js \
+  browserify tests/**/*.js \
     -t es2020 \
     -p proxyquire-universal \
     -p tape-istanbul/plugin \
-      | "$tape_run" \
-      | "$tape_istanbul" \
-      && "$istanbul" report
+      | tape-run \
+      | tape-istanbul \
+      && istanbul report
 }
 
 test_server () {
@@ -50,18 +40,18 @@ test_server () {
 }
 
 test_browser () {
-  NODE_ENV=test "$zuul" tests/browser/*
+  NODE_ENV=test zuul tests/browser/*
 }
 
 test_browser_local () {
   lint
   check_deps
-  NODE_ENV=test "$zuul" --local 8080 -- tests/browser/*
+  NODE_ENV=test zuul --local 8080 -- tests/browser/*
 }
 
 check_deps () {
-  "$dependency_check" . --entry 'index.js'
-  "$dependency_check" . --entry 'index.js' --extra --no-dev \
+  dependency-check . --entry 'index.js'
+  dependency-check . --entry 'index.js' --extra --no-dev \
     -i xhr
 }
 


### PR DESCRIPTION
per convo in IRC, `npm run` makes its dependencies' binaries available on the `PATH` so variablizing the `.bin` paths isn't necessary.

I didn't touch the instrument script, as that doesn't appear to be in npm scripts and I don't really know what it does. Keeps telling me `printf` is deprecated.

Fixes #168