### PR TITLE
Clarify getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ do:
 ```bash
 $ mkdir -p 'dist/'
 $ curl 'localhost:8080' > 'dist/index.html'
-$ curl 'localhost:8080/bundle.js' > 'dist/bundle.js'
+$ curl 'localhost:8080/client.js' > 'dist/client.js'
 ```
 All using a couple of shell commands and `.js` files, no grandiose boilerplate
 needed.


### PR DESCRIPTION
The first example in README is mentioning `client.js`. When it serve via `budo`,
I think the client-side script is the `client.js` not `bundle.js` in this case.