### PR TITLE
docs: add ecosystem heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@
       Handbook
     </a>
     <span> | </span>
-      Packages
+      <a href="https://github.com/YerkoPalma/awesome-choo">
+        Ecosystem
+      </a>
     <span> | </span>
     <a href="https://github.com/yoshuawuyts/choo/blob/master/.github/CONTRIBUTING.md">
       Contributing


### PR DESCRIPTION
Think it'd be cool to have `awesome-choo` be a bit more front and center (': - def better than a dead "packages" link :sparkles: