### PR TITLE
Update Input Example to latest version of choo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@
 - __very cute:__ choo choo!
 
 ## Demos
-- :truck: [Input example](http://requirebin.com/?gist=e589473373b3100a6ace29f7bbee3186)
+- :truck: [Input example](http://requirebin.com/?gist=229bceda0334cf30e3044d5f5c600960)
   ([repo](examples/title/))
 - :water_buffalo: [HTTP effects example](https://fork-fang.hyperdev.space/)
   ([repo](https://hyperdev.com/#!/project/fork-fang))


### PR DESCRIPTION
When I first started using choo, I used the requirebin link first, but then after I wanted to use it in a project it wouldn't work.  After a bit of headache it turned out the requirebin was using version 1.0 but choo 3 was installed.

The very next day, a colleague of mine went through the same problem! 

So I wanted to update this to prevent the pain from happening to anyone else.