### PR TITLE
add .use() API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,9 +408,15 @@ document.body.appendChild(tree)
 
 Generally people using `choo` shouldn't be too worried about the specifics of
 `plugins`, as the internal API is (unfortunatly by necessecity) quite complex.
-After all they're the most powerful way to modify a `choo` appliction. If you
-want to learn more about creating your own `plugins`, and which `hooks` are
-available, head on over to [app.use()](#appusehooks).
+After all they're the most powerful way to modify a `choo` appliction.
+
+__:warning: Warning :warning:: plugins should only be used as a last resort.
+It creates peer dependencies which makes upgrading versions and switching
+frameworks a lot harder. Please exhaust all other options before using
+plugins.__
+
+If you want to learn more about creating your own `plugins`, and which `hooks`
+are available, head on over to [app.use()](#appusehooks).
 
 ## Badges
 Using `choo` in a project? Show off which version you've used using a badge:
@@ -484,6 +490,11 @@ There are several `hooks` that are picked up by `choo`:
   `action` is fired.
 - __onStateChange(action, state, prev, caller, createSend):__ called after a
   reducer changes the `state`.
+
+__:warning: Warning :warning:: plugins should only be used as a last resort.
+It creates peer dependencies which makes upgrading versions and switching
+frameworks a lot harder. Please exhaust all other options before using
+plugins.__
 
 `createSend()` is a special function that allows the creation of a new named
 `send()` function. The first argument should be a string which is the name, the

--- a/index.js
+++ b/index.js
@@ -18,17 +18,21 @@ module.exports = choo
 function choo (opts) {
   opts = opts || {}
 
-  const _store = start._store = barracks(xtend(opts, { onStateChange: render }))
+  const _store = start._store = barracks()
   var _router = start._router = null
   var _defaultRoute = null
   var _rootNode = null
   var _routes = null
   var _frame = null
 
+  _store.use({ onStateChange: render })
+  _store.use(opts)
+
   start.toString = toString
   start.router = router
   start.model = model
   start.start = start
+  start.use = use
 
   return start
 
@@ -83,10 +87,6 @@ function choo (opts) {
   // update the DOM after every state mutation
   // (obj, obj, obj, str, fn) -> null
   function render (data, state, prev, name, createSend) {
-    if (opts.onStateChange) {
-      opts.onStateChange(data, state, prev, name, createSend)
-    }
-
     if (!_frame) {
       _frame = nanoraf(function (state, prev) {
         const newTree = _router(state.location.pathname, state, prev)
@@ -107,6 +107,13 @@ function choo (opts) {
   // (str?, obj) -> null
   function model (model) {
     _store.model(model)
+  }
+
+  // register a plugin
+  // (obj) -> null
+  function use (hooks) {
+    assert.equal(typeof hooks, 'object', 'choo.use: hooks should be an object')
+    _store.use(hooks)
   }
 
   // create a new router with a custom `createRoute()` function

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "barracks": "^8.0.0",
+    "barracks": "^8.1.1",
     "document-ready": "~1.0.2",
     "global": "^4.3.0",
     "hash-match": "^1.0.2",


### PR DESCRIPTION
Adds the `app.use()` API method. Relies on https://github.com/yoshuawuyts/barracks/pull/58 to be merged first.

This patch only adds sugar around the existing hooks. It doesn't add new functionality, but makes it so multiple `hooks` can be registered without leaking details about the `hooks` API to consumers.

In practice this means that if say you want to add a logger, time travel and hot module reloading utilities, prior to this patch the API would be:
```js
const TimeTravel = require('choo-time-travel')
const Hmr = require('choo-hmr')
const Log = require('choo-log')
const choo = require('choo')

const timeTravel = TimeTravel()
const hmr = hmr()
const log = log()

const app = choo({
  initialState: function () {
    // something similar is needed for hmr, not a thing yet
    return hmr.initialState
  },
  onStateChange: function (data, state, prev, caller, createSend) {
    log.onStateChange(data, state, prev, caller, createSend)
  },
  onAction: function (data, state, name, caller, createSend) {
    log.onAction(data, state, prev, caller, createSend)
    timeTravel.onAction(data, state, prev, caller, createSend)
  },
  onError: function (err, state, createSend) {
    log.onError(err, state, createSend)
  }
})

app.model(timeTravel.model)

const tree = app.start()
document.body.appendChild(tree)
```

With this patch it would become:
```js
const TimeTravel = require('choo-time-travel')
const hmr = require('choo-hmr')
const log = require('choo-log')
const choo = require('choo')

const timeTravel = TimeTravel()
const app = choo()

app.use(timeTravel)
app.use(hmr())
app.use(log())

app.model(timeTravel.model)

const tree = app.start()
document.body.appendChild(tree)
```

The goal here is to prevent leaking specifics of the (by necessity) quite complicated `hooks` API spilling over into consumer land; providing a neat way to append multiple hooks onto the same application.

The alternative approach to `.use()` would be to provide a separate package that can combine multiple handlers into a single handler (like `.use()` does under the hood), but I feel it would be so commonly used it'd be cleaner to add it to the API directly and create guides and docs for using it.

---
But I understand there might be concerns with adding `.use()`. @shama posted the following in https://github.com/yoshuawuyts/choo/issues/152#issuecomment-232224893:

> Plugins by their nature are convenient and is why every framework implements an API for it. But my goal has been to try something different then what everyone else currently does. I want to see if a client side ecosystem can be built without peer deps.

I feel that peer deps are a legitimate concern, and can definitely become the source of upgrading pains. That said, peer deps do provide a very attractive tradeoff: they remove boilerplate and make it so that application level code becomes front and center, rather than being clouded by the intricacies of hooking up generic functions to framework specific APIs.

I sincerely hope we can get any sort of plugins in the ecosystem to have any sort of complicated core functionality live in a separate package, with a `choo` specific wrapper available for convenience. I'm not sure what the best approach for this is, but I'm sure we can figure it out and then write it down for others to follow (like we've started to do with [designing for reusability](https://github.com/yoshuawuyts/choo-handbook/blob/master/designing-for-reusability.md)).

I hope this makes sense, and y'all can see where I'm coming from for adding `.use()`. Keen to hear your thoughts! This would be a minor patch btw. Thanks! :sparkles:

---

Backlog:
- https://github.com/yoshuawuyts/choo/issues/152

Prerequisite for:
- https://github.com/yoshuawuyts/barracks/pull/50
- time travel plugin