### PR TITLE
Improve README data flow diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,35 @@ efficiently rendered on the screen.
 In turn when the `views` are rendered, the `user` can interact with elements by
 clicking on them, triggering `actions` which then flow back into the
 application logic. This is the _unidirectional_ architecture of `choo`.
+
 ```txt
- ┌─────────────────┐
- │  Subscriptions ─┤     User ───┐
- └─ Effects  ◀─────┤             ▼
- ┌─ Reducers ◀─────┴──Actions── DOM ◀┐
- │                                   │
- └▶ Router ─────State ───▶ Views ────┘
++----------+     changes trigger       +-------+
+|          |<-------------------------<|       |
+|  Router  |                           | State |     initialize
+|          |                     +---->|       |<-----------------+
++----------+              modify |     +-------+                  |
+  v                              |                                |
+  | renders  +-------------------|--------------------------------|----+
+  v          | Model             |                                |    |
++---------+  |                   ^      call    call              ^    |
+|         |  | Subscriptions  Reducers <----+  +----> Effects  Initial |
+|  Views  |  |       v                      |  |        v      States  |
+|         |  |       |                      |  |        |              |
++---------+  +-------|----------------------|--|--------|--------------+
+  v                  |                      ^  ^        |
+  | update           |     emit           +---------+   | asynchronously
+  v                  +------------------->|         |   | emit
++---------+                               | Actions |<--+
+|   DOM   |>----------------------------->|         |
++---------+ bound event handlers dispatch +---------+
+  v     ^                                   |     |
+  |     |                                   |     |
+  v     ^                            +--------+ +----------+
++---------+                          | Unique | | Optional |
+| People! |                          | Names  | | Payloads |
++---------+                          +--------+ +----------+
 ```
+
 - __user:__ 🙆
 - __DOM:__ the [Document Object Model][dom] is what is currently displayed in
   your browser


### PR DESCRIPTION
This pull request replaces the current README data-flow diagram with a new one. My goals for the new one were to:
1. Bring together more of the vocabulary otherwise spread out in the description of each component. For example, I've tracked verb usage, like "subscriptions emit events" and "actions call reducers". Not just nouns.
2. Depict clearly that "models" are aggregates of subscriptions, reducers, effects, and initial states. They have no role in and of themselves.
3. Retain the cyclical overall look of the current diagram, with stronger hints about direction of flow.
4. Avoid mixing box-drawing and potentially variable-width Unicode symbols, so it renders reliably without alignment issues.
5. Users are people!

This has been very useful in sorting out my only understanding of what choo seems to be going for. That being said, I fully expect I might have tripped up somewhere.

Apart from the mistakes I don't know about, there are a few ways I think this might be improved still:
1. Call out more prominently that asynchrony lives in Effects. At least for me personally, it took a little while to deduce that the server side sneaks in somewhere in the action-effect-action cycle.
2. Clarify that Effects and Reducers share a single namespace unified by `send()`.
3. Work the Model namespace thing in a more teachable way.  I am not entirely convinced that I understand them yet.

Hope this is helpful.

Best,

K
