### PR TITLE
Fix choo/http usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ app.model({
   state: { items: [] },
   effects: {
     addAndSave: (data, state, send, done) => {
-      http.post('/todo', {body: data.payload, json: true}, (err, res, body) => {
+      http.post('/todo', {json: data.payload}, (err, res, body) => {
         data.payload.id = body.id
         send('todos:add', data, done)
       })


### PR DESCRIPTION
Hi! Awesome framework!

I found an error in the effects example in the readme.
The xhr docs state that the payload should be passed to the `json` parameter.

https://github.com/Raynos/xhr#optionsjson

Maybe it depends on the version of xhr ? I got version 2.2.2 installed.
First time I'm using raynos/xhr, had to step through the debugger to find what I was doing wrong =P

Hope this helps,

Cheers