### PR TITLE
Readme: fix effects example

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,15 +297,16 @@ app.model({
   namespace: 'todos',
   state: { items: [] },
   effects: {
-    addAndSave: (data, state, send, done) => {
-      http.post('/todo', {json: data.payload}, (err, res, body) => {
-        data.payload.id = body.id
-        send('todos:add', data, done)
+    fetch: (data, state, send, done) => {
+      http('/todos', (err, res, body) => {
+        send('todos:receive', body, done)
       })
     }
   },
   reducers: {
-    add: (data, state) => ({ items: state.items.concat(data.payload) })
+    receive: (data, state) => {
+      return { items: data }
+    }
   }
 })
 ```


### PR DESCRIPTION
Per #186. We could introduce `xtend` here to make a copy of `data` in order to keep it `addAndSave`, but if the purpose of this example is to illustrate an effect, that may seem overkill (unless accompanied by a longer explanation.