### PR TITLE
prev.params should always exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ function choo (opts) {
   // create a new router with a custom `createRoute()` function
   // (str?, obj, fn?) -> null
   function createRouter (defaultRoute, routes, createSend) {
-    var prev = {}
+    var prev = { params: {} }
     return sheetRouter(defaultRoute, routes, createRoute)
 
     function createRoute (routeFn) {

--- a/tests/browser/routing.js
+++ b/tests/browser/routing.js
@@ -163,4 +163,21 @@ test('routing', function (t) {
 
     app.start()
   })
+
+  t.test('prev.params always exists', function (t) {
+    t.plan(1)
+
+    const choo = require('../..')
+    const app = choo()
+
+    app.router('/users/123', (route) => [
+      route('/users', [
+        route('/:user', function (state, prev) {
+          t.ok(prev.params)
+        })
+      ])
+    ])
+
+    app.start()
+  })
 })


### PR DESCRIPTION
The code I suggested in [#166 (comment)](https://github.com/yoshuawuyts/choo/issues/166#issuecomment-241204080) requires you check if `prev.params` exists before checking one of its properties, otherwise you'll throw a runtime error on the first load.

```javascript
const view = (state, prev, send) => {
  if (!prev.params || !prev.params.user || prev.params.user !== state.params.user) {
    send('fetch', state.params.user)
  }
  return html`<div>...</div>`
}
```

This pull request lets you always check properties of `prev.params`:
```javascript
const view = (state, prev, send) => {
  if (!prev.params.user || prev.params.user !== state.params.user) {
    send('fetch', state.params.user)
  }
  return html`<div>...</div>`
}
```