### PR TITLE
added onStart hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,9 @@ There are several `hooks` that are picked up by `choo`:
   `action` is fired.
 - __onStateChange(data, state, prev, caller, createSend):__ called after a
   reducer changes the `state`.
+- __onStart():__ called on `choo.start` _before_ the app is appended to the DOM,
+  and also with no access to the model state. This hook is intended for
+  initialize of some third party libraries.
 
 __:warning: Warning :warning:: plugins should only be used as a last resort.
 It creates peer dependencies which makes upgrading versions and switching

--- a/examples/async-counter/client.js
+++ b/examples/async-counter/client.js
@@ -40,5 +40,12 @@ app.router((route) => [
   route('/', mainView)
 ])
 
+app.use({
+  onStart: () => {
+    console.log('Ready to go!')
+  }
+})
+
 const tree = app.start()
+
 document.body.appendChild(tree)

--- a/index.js
+++ b/index.js
@@ -113,6 +113,10 @@ function choo (opts) {
   // (obj) -> null
   function use (hooks) {
     assert.equal(typeof hooks, 'object', 'choo.use: hooks should be an object')
+    if (hooks && hooks.onStart) {
+      assert.equal(typeof hooks.onStart, 'function', 'choo.onStart: onStart hook must be a function')
+      hooks.onStart()
+    }
     _store.use(hooks)
   }
 


### PR DESCRIPTION
ref: #232 

This probably isn't ready to merge yet, because:

- There is no test (I couldn't figure out _how_ to add them).
- It doesn't work as expected. It's called before the app is added to the DOM and has no access to the state.

The thing of having it before the DOM is updated is not that important, but it definitely should have access to the state. Any help or opinion is appreciated.