### PR TITLE
feat(http): remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ we support - while secretly sneaking in some performance upgrades. Enjoy!
   [pull-request]()
 - :exclamation: swap `state` and `data` argument order |
   [issue](https://github.com/yoshuawuyts/choo/issues/179)
+- :exclamation: remove `choo/http`. Use [xhr](https://github.com/naugtur/xhr)
+  instead | [pull-request](https://github.com/yoshuawuyts/choo/pull/269)
 - update `router` to use memoization |
   [issue](https://github.com/yoshuawuyts/sheet-router/issues/17) |
   [pull-request](https://github.com/yoshuawuyts/sheet-router/pull/34)

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Examples of effects include: performing
 [localstorage][localstorage].
 
 ```js
-const http = require('choo/http')
+const http = require('xhr')
 const choo = require('choo')
 const app = choo()
 app.model({

--- a/http.js
+++ b/http.js
@@ -1,1 +1,0 @@
-module.exports = require('xhr')

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   ],
   "files": [
     "index.js",
-    "http.js",
     "html.js",
     "dist/"
   ],
@@ -42,7 +41,6 @@
     "hash-match": "^1.0.2",
     "nanoraf": "^2.1.1",
     "sheet-router": "^4.0.1",
-    "xhr": "^2.2.0",
     "xtend": "^4.0.1",
     "yo-yo": "^1.2.2"
   },


### PR DESCRIPTION
Removes `choo/http`. In previous IRC conversations we kind of came to the conclusion that this doesn't make a lot of sense to bundle in anymore given that a lot of choo's narrative is now about how to glue views, logic and state. We weren't mentioning it anywhere in the README anymore anyway, so it might make sense to deprecate in its entirety.

Having thoughts on this would be highly welcome! - Thanks!