### PR TITLE
Fix router example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ function mainView (state, prev, send) {
   `
 }
 
-app.router(['/', mainView])
+app.router([
+  ['/', mainView]
+])
 
 const tree = app.start()
 document.body.appendChild(tree)


### PR DESCRIPTION
AFAICT `app.router` expects a list of pairs, whereas the README exemplifies with a single pair.