### PR TITLE
fix(mount): return node

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,15 @@ function choo (opts) {
 
     const tree = _router(state.location.href, state)
     _rootNode = tree
+    tree.done = done
+
     return tree
+
+    // allow a 'mount' function to return the new node
+    // html -> null
+    function done (newNode) {
+      _rootNode = newNode
+    }
   }
 
   // update the DOM after every state mutation

--- a/mount.js
+++ b/mount.js
@@ -5,30 +5,36 @@ const yo = require('yo-yo')
 
 module.exports = mount
 
-function mount (selector, tree) {
-  assert.equal(typeof selector, 'string')
-  assert.equal(typeof tree, 'object')
+// (str, html) -> null
+function mount (selector, newTree) {
+  assert.equal(typeof selector, 'string', 'choo/mount: selector should be a string')
+  assert.equal(typeof newTree, 'object', 'choo/mount: newTree should be an object')
+
+  const done = newTree.done
 
   documentReady(function onReady () {
-    const oldTree = document.querySelector(selector)
-    assert.ok(oldTree, 'could not query selector: ' + selector)
+    const _rootNode = document.querySelector(selector)
+    assert.ok(_rootNode, 'could not query selector: ' + selector)
 
-    // copy script tags from the old tree to the new tree so
+    // copy script tags from the old newTree to the new newTree so
     // we can pass a <body> element straight up
-    if (oldTree.nodeName === 'BODY') {
-      const children = oldTree.childNodes
+    if (_rootNode.nodeName === 'BODY') {
+      const children = _rootNode.childNodes
       for (var i = 0; i < children.length; i++) {
         if (children[i].nodeName === 'SCRIPT') {
-          tree.appendChild(children[i].cloneNode(true))
+          newTree.appendChild(children[i].cloneNode(true))
         }
       }
     }
 
-    const newNode = yo.update(oldTree, tree)
-    assert.equal(newNode, oldTree, 'choo/mount: The DOM node: \n' +
-      newNode.outerHTML + '\n is not equal to \n' + oldTree.outerHTML +
+    const newNode = yo.update(_rootNode, newTree)
+    assert.equal(newNode, _rootNode, 'choo/mount: The DOM node: \n' +
+      newNode.outerHTML + '\n is not equal to \n' + newTree.outerHTML +
       'choo cannot begin diffing.' +
       ' Make sure the same initial tree is rendered in the browser' +
       ' as on the server. Check out the choo handbook for more information')
+
+    // pass the node we mounted on back into choo
+    if (done) done(newNode)
   })
 }


### PR DESCRIPTION
This fixes an issue where `mount.js` wasn't allowing `choo` to hook into the render; this fixes it. Oops all the way :sparkles:

### changes
- make `mount.js` internal naming consistent with `index.js` internals
- allow `mount.js` to return the new node back into `index.js`