### PR TITLE
check if a hash is a valid selector [fixes uncaught error]

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,8 +157,12 @@ function createLocationModel (opts) {
   // (obj, obj) -> obj
   function updateLocation (state, data) {
     if (opts.history !== false && data.hash && data.hash !== state.hash) {
-      const el = document.querySelector(data.hash)
-      if (el) el.scrollIntoView(true)
+      try {
+        const el = document.querySelector(data.hash)
+        if (el) el.scrollIntoView(true)
+      } catch (e) {
+        return data
+      }
     }
     return data
   }


### PR DESCRIPTION
Greeting 👋👋

this PR fixes an issue I had pertaining to the function `updateLocation`

Some hashes may not be valid selector for `document.querySelector` (for instance, if an email such as choo@example.com is used as a hash) and will actually crash an app due the error not being handled.  I would get this error for example:

 ```js
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '#choo@example.com' is not a valid selector.
    at Object.updateLocation [as update] (http://localhost:8080/bundle.js:1727:29)
    at http://localhost:8080/bundle.js:992:55
updateLocation @ index.js:161
(anonymous) @ index.js:226
```
  
I think ideally it would be best to make a separate module such as `isValidSelector` and use that here,  but this `try/catch` works for now.