### PR TITLE
Update README.md with correct order of arguments in reducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ app.model({
   namespace: 'todos',
   state: { values: [] },
   reducers: {
-    add: function (data, state) {
+    add: function (state, data) {
       return { todos: data }
     }
   },


### PR DESCRIPTION
I think I found an error in the readme where the order of arguments is still reflecting the old v3.