### PR TITLE
Update README.md: change parameter name in docu of plugin hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ app.model({
   namespace: 'todos',
   state: { values: [] },
   reducers: {
-    add: function (data, state) {
+    add: function (state, data) {
       return { todos: data }
     }
   },

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ There are several `hooks` and `wrappers` that are picked up by `choo`:
 - __wrapSubscriptions(fn):__ wraps a `subscription` to add custom behavior
 - __wrapReducers(fn):__ wraps a `reducer` to add custom behavior
 - __wrapEffects(fn):__ wraps an `effect` to add custom behavior
-- __wrapInitialState(fn):__ mutate the complete initial `state` to add custom
+- __wrapInitialState(state):__ mutate the complete initial `state` to add custom
   behavior - useful to mutate the state before starting up
 
 __:warning: Warning :warning:: plugins should only be used as a last resort.


### PR DESCRIPTION
Just a minor change in the README. I think in the documentation of the plugin hooks the parameter name of wrapInitialState should be named state instead of fn. 