### PR TITLE
Update README to reflect current size

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <strong>Fun functional programming</strong>
 </div>
 <div align="center">
-  A <code>5kb</code> framework for creating sturdy frontend applications
+  A <code>7kb</code> framework for creating sturdy frontend applications
 </div>
 
 <br />
@@ -94,7 +94,7 @@
 </details>
 
 ## Features
-- __minimal size:__ weighing `5kb`, `choo` is a tiny little framework
+- __minimal size:__ weighing `7kb` (`18kb` with optional html module), `choo` is a tiny little framework
 - __single state:__ immutable single state helps reason about changes
 - __small api:__ with only 6 methods, there's not a lot to learn
 - __minimal tooling:__ built for the cutting edge `browserify` compiler


### PR DESCRIPTION
I really like this framework, great job.

However, I showed it to some colleagues and immediately they called bs on `5kb` framework size and well technically they are right. It's `7.3kb` plus a basically essential `11kb` html module for total of `18.3kb`. That's hardly something to be ashamed off, in fact it's great, but it's not `5kb` as stated.

It's a very minor niggle but hey, we all know how this industry attracts pedants and this framework lost a bit of credibility almost immediately because of this claim.

Sorry to be "that guy", please consider updating README.