### PR TITLE
Depend on morphdom <2.2 due to regressions in later versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "nanoraf": "^2.1.1",
     "sheet-router": "^4.0.1",
     "xtend": "^4.0.1",
-    "yo-yo": "^1.2.2"
+    "yo-yo": "^1.2.2",
+    "morphdom": "<2.2"
   },
   "devDependencies": {
     "append-child": "~1.0.0",

--- a/scripts/test
+++ b/scripts/test
@@ -54,7 +54,8 @@ check_deps () {
   dependency-check . --entry 'index.js'
   dependency-check . --entry 'index.js' --extra --no-dev \
     -i document-ready \
-    -i global
+    -i global \
+    -i morphdom
 }
 
 # set CLI flags


### PR DESCRIPTION
I experience at least one regression with morphdom >= 2.2, where `selectedIndex` doesn't get set on `select` elements. This doesn't happen with version 2.1. This change makes sure that choo locks down the version of morphdom. I'm not sure if it's the right way to do it since morphdom is an indirect dependency, so would value any input on how it eventually ought to be done.