### PR TITLE
Ignore state updates for the dom when on node

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ function choo (opts) {
   // update the DOM after every state mutation
   // (obj, obj, obj, str, fn) -> null
   function render (state, data, prev, name, createSend) {
+    if (typeof window === 'undefined') {
+      return
+    }
+
     if (!_frame) {
       _frame = nanoraf(function (state, prev) {
         const newTree = _router(state.location.href, state, prev)


### PR DESCRIPTION
Should patch https://github.com/yoshuawuyts/choo/issues/388 in conjunction with the recently updated sheet-router. Confirmed by running his example:

```js
> const choo = require('choo')
undefined
> const html = require('choo/html')
undefined
> const app = choo()
undefined
> app.router(['/', () => html`<h1>Hello Tokyo!</h1>`])
undefined
> app.toString('/')
'<h1>Hello Tokyo!</h1>'
```