### PR TITLE
hash fix: wait to run scrollIntoView

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,5 +118,7 @@ function scrollIntoView () {
 }
 
 function createLocation () {
-  return window.location.pathname.replace(/\/$/, '')
+  var pathname = window.location.pathname.replace(/\/$/, '')
+  var hash = window.location.hash.replace(/^#/, '/')
+  return pathname + hash
 }

--- a/index.js
+++ b/index.js
@@ -63,7 +63,9 @@ function Framework (opts) {
       bus.on('pushState', function (href) {
         if (href) window.history.pushState({}, null, href)
         bus.emit('render')
-        scrollIntoView()
+        setTimeout(function () {
+          scrollIntoView()
+        }, 0)
       })
 
       if (opts.href !== false) {
@@ -116,7 +118,5 @@ function scrollIntoView () {
 }
 
 function createLocation () {
-  var pathname = window.location.pathname.replace(/\/$/, '')
-  var hash = window.location.hash.replace(/^#/, '/')
-  return pathname + hash
+  return window.location.pathname.replace(/\/$/, '')
 }


### PR DESCRIPTION
I'm working on porting [minidocs to choo v5](https://github.com/freeman-lab/minidocs/tree/choo-v5) and found a couple issues with hash behavior.

I'm open to revising things if needed, or even just using this PR as inspiration for better ones if there are other ways to solve things.

Here's a description of changes:

### `scrollIntoView`

I found that the check for an id was failing because it needed to wait for the next tick: https://github.com/yoshuawuyts/choo/blob/master/index.js#L113

This PR puts `scrollIntoView` inside a `setTimeout`.

> edit: removed `createLocation` changes