### PR TITLE
add scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,22 @@ node_js:
 - '6'
 sudo: false
 language: node_js
+env:
+  - CXX=g++-4.8
+notifications:
+  irc:
+    on_success: change
+    on_failure: always
+    use_notice: true
+    channels:
+      - "chat.freenode.net#choo"
+    template:
+      - "%{repository_slug} #%{build_number} %{result}: %{build_url}"
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
-      - xvfb
-before_install:
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+      - g++-4.8
 script: npm run test
 # after_script: npm i -g codecov.io && cat ./coverage/lcov.info | codecov
-env:
-  global:
-  - secure: t6MYp/rV/HXKQ8yb21fDMAV9fkwZmPFJ/4Za4TeXvVOojFan4Q40j5VZF6wiVBHTemctMRueQ2iuGl8pgNX3jqRHMKvNS5zKCCUHYvmyvMLQiWpkDC3Lz3R9oz2fooY1f0fpnzaE0TmJHoZQcVDYDTZSk/o6fNXJQnI4SUG/nmnb3VAA0H8lRZ1OidkAbBzJNFj8i0ZTuaqwo0uQVhNDSvLLKgM94ryF+DB+c0vKuZr85wn+xnuJ1ZPZM5S+uZrOAY+TnwD1QvstULHnbF6sqH5WuUkUCHpXV84Hz2pr7GL7yCkj65XoNoqvnoR5ETv8yBa5r/OccrCY9NqXSCv/zWiS4vRWybrJq0Mdx67cXHKHjbQMrILHsbRBDxbCJwn+LAQlwRUoktEcI9bNRUhi0Wt/LQmLvyfldt7mMvgl+7srBdlZWPoTZWRZKqu04XpYTaqAnAeNOjfSOOuB29uVTRu7n9pCeKA/gDNYOWCF3CfN++ztbL+E2OpPnpoRWwoSXnXzFQrLofq6zF1bpIrb5UpaqNYGX+PifUYX+hRYKLdOqqAS3JlJBqG+0ArRZgf3sm/uk4ZDesV5Ee9qB7Ty32Vh66wmU8P6wZjgare4TL+hcsgtNRrd6+kZwXfn0mqcqeFovN2yPpQSmF1U5+ki8+o1NcFFYdeucWa7E9ULkVE=
-  - secure: w0Bkyfc2O/DeSBiIJ3tRnV6zgRbZNCO3SZZikqga/oUWdeIeCB8HDx9eBNvvJH2PF3tyUtRbfbwR+yZotmX/pRF9wc8W8RMFg9xQgsho/WtUG9bQVWGTyeCd9+hCxh9+VnJP0t4YwNOc4UwheRWb+5bxgYZZABxT3VmGBeshFNlryGY9xGMVbDQeF1M3GpQdt51Kud8V2APzShyKdi0YjQM6eC8Jfcl58chrnWDBcGtynREM+fT3rAM7MMEAZf5cRYVze/V/UqFvwaMsu1niCL1eUyg3gf3NpkGIjd9pi7XmYfbRogx41/WPcpeq1susI2hrHdFmco+Ykv6ebrhA7qqQT0MKOSezN2lmoGnr7q+954qxPN7wQMnSCAYZ4Rk1S2Zu1HQBUW4UyjK+yvVnj0HOZF2ksIoNz46zFesa7+SlBN10VkVpBYIHW8GZn9+AanjGJbIPJ7I98Ga7rbU4nBQWpP5lc5vVflMmtVGOjcY37S+FxB05oPLnNU4AJivZFdbdf0xYrc5eWNC/t3+JLZ3BJyD2ZTiWbNtJT4YIdKpV9RdjV/u60XnxLKmGFuPIn+b+CKPW0+IM9ooyJK4mir8ET2uv4A926Ocgs2qzq9geU8IJ8WYLS1I9OgT/IM9EgJEeBeUOaeukW4t1V8pVRXDRsIqOleyHiBQ6bR7GH6I=

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "A 4kb framework for creating sturdy frontend applications",
   "main": "index.js",
   "scripts": {
+    "build": "mkdir -p dist/ && browserify index -p bundle-collapser/plugin > dist/bundle.js && browserify index -g unassertify -g uglifyify -p bundle-collapser/plugin | uglifyjs > dist/bundle.min.js && zopfli -i 100 dist/bundle.min.js && wc -c < dist/bundle.min.js.gz | pretty-bytes",
     "deps": "dependency-check --entry ./html.js . && dependency-check . --extra --no-dev --entry ./html.js",
+    "inspect": "browserify --full-paths index -g unassertify -g uglifyify | discify --open",
+    "prepublish": "npm run build",
     "start": "bankai start example --open --optimize",
-    "test": "standard && npm run deps && node test.js",
-    "build:dev": "echo 'to be implemented'",
-    "build:min": "echo 'to be implemented'",
-    "prepublish": "npm run build:dev && npm run build:min"
+    "test": "standard && npm run deps && node test.js"
   },
   "repository": "yoshuawuyts/choo",
   "keywords": [
@@ -31,9 +31,17 @@
     "nanorouter": "^2.0.0"
   },
   "devDependencies": {
+    "browserify": "^14.1.0",
+    "bundle-collapser": "^1.2.1",
     "dependency-check": "^2.8.0",
+    "discify": "^1.6.0",
+    "node-zopfli": "^2.0.2",
+    "pretty-bytes-cli": "^2.0.0",
     "spok": "^0.8.1",
     "standard": "^9.0.1",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "uglifyify": "^3.0.4",
+    "uglifyjs": "^2.4.10",
+    "unassertify": "^2.0.4"
   }
 }


### PR DESCRIPTION
Restores the CDN prebuild scripts (removed in the `5.0.0` refactor)

<img width="629" alt="screen shot 2017-03-31 at 21 00 40" src="https://cloud.githubusercontent.com/assets/2467194/24565632/55470ca2-1656-11e7-9f38-5168d59b085d.png">

