### PR TITLE
optimize example further

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,6 +13,8 @@
     "choo-expose": "^1.0.0",
     "choo-log": "^6.0.0",
     "choo-persist": "^3.0.0",
+    "microbounce": "^1.0.0",
+    "microframe": "^1.0.0",
     "sheetify": "^6.0.1",
     "todomvc-app-css": "^2.0.6",
     "todomvc-common": "^1.0.3",

--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ var assert = require('assert')
 var onHistoryChange = require('./lib/history')
 var onHref = require('./lib/href')
 
-module.exports = Framework
+module.exports = Choo
 
-function Framework (opts) {
+function Choo (opts) {
   opts = opts || {}
 
   var routerOpts = {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deps": "dependency-check --entry ./html.js . && dependency-check . --extra --no-dev --entry ./html.js",
     "inspect": "browserify --full-paths index -g unassertify -g uglifyify | discify --open",
     "prepublish": "npm run build",
-    "start": "bankai start example --open --optimize",
+    "start": "bankai start example --optimize",
     "test": "standard && npm run deps && node test.js"
   },
   "repository": "yoshuawuyts/choo",


### PR DESCRIPTION
Expands on #460, debounces input & removes long frames from key events by pushing them to the start of the next frame. The remaining long frames are because of choo's diffing function in the case of large numbers of todos - which is something that can be optimized through a combination of Nanocomponent and https://github.com/yoshuawuyts/nanomorph/issues/8.

### screenshot

<img width="1280" alt="screen shot 2017-04-01 at 19 59 06" src="https://cloud.githubusercontent.com/assets/2467194/24581233/dca0f1ec-1717-11e7-817c-4355d3989e18.png">
