### PR TITLE
call DOMContentLoaded on next frame

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,15 @@ function Choo (opts) {
   }
 
   function start () {
+    if (hasPerformance && timingEnabled) {
+      window.performance.mark('choo:renderStart')
+    }
     tree = router(createLocation())
+    if (hasPerformance && timingEnabled) {
+      window.performance.mark('choo:renderEnd')
+      window.performance.measure('choo:render', 'choo:renderStart', 'choo:renderEnd')
+    }
+
     rerender = nanoraf(function () {
       if (hasPerformance && timingEnabled) {
         window.performance.mark('choo:renderStart')
@@ -108,8 +116,15 @@ function Choo (opts) {
 
     onReady(function () {
       setTimeout(function () {
+        if (hasPerformance && timingEnabled) {
+          window.performance.mark('choo:mountStart')
+        }
         nanomount(root, newTree)
         tree = root
+        if (hasPerformance && timingEnabled) {
+          window.performance.mark('choo:mountEnd')
+          window.performance.measure('choo:mount', 'choo:mountStart', 'choo:mountEnd')
+        }
       }, 0)
     })
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "dependencies": {
     "bel": "^4.5.1",
-    "document-ready": "^2.0.1",
     "nanobus": "^3.0.0",
     "nanomorph": "^4.0.0",
     "nanomount": "^1.0.0",


### PR DESCRIPTION
This delays emitting `DOMContentLoaded` until the start of the next frame. Should help squash long frames when booting. Apparently calling `window.requestAnimationFrame` as the direct result of the event pushes stuff to execute on the same frame. So hence wrapping it to run on the next tick.

### Before
There's a 68ms long frame because `DOMContentLoaded` fires and triggers more stuff in the same frame.

<img width="826" alt="screen shot 2017-04-04 at 19 46 36" src="https://cloud.githubusercontent.com/assets/2467194/24670738/8e6ed67e-196f-11e7-880f-7c85c90a1182.png">


### After
It's now cleanly split into two smaller frames

<img width="826" alt="screen shot 2017-04-04 at 19 46 05" src="https://cloud.githubusercontent.com/assets/2467194/24670783/b98fb968-196f-11e7-9a74-c50b31081daa.png">
