### PR TITLE
Clarify `app.use()` emitter event usage (solves #470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Choo fires messages when certain events happen:
 - __`.on('render')`__: when the DOM re-renders
 - __`.on('pushState')`__: when the history API is triggered
 
-The `render` event should be emitted (`emitter.emit('render')`) whenever you wan't the app to re-render the DOM - it won't happen on its own except when you navigate between routes.
+The `render` event should be emitted (`emitter.emit('render')`) whenever you want the app to re-render the DOM - it won't happen on its own except when you navigate between routes.
 
 The `pushState` can be emitted to navigate between routes: `emitted.emit('pushState', '/some/route')`.
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ of [nanobus](https://github.com/yoshuawuyts/nanobus/). You can listen to
 messages by calling `emitter.on()` and emit messages by calling `emitter.emit()`.
 
 Choo fires messages when certain events happen:
-- __`.on('DOMContentLoaded')`__: when the DOM has succesfully finished loading
+- __`.on('DOMContentLoaded')`__: when the DOM has succesfully finished loading. Re-rendering and navigation will not work until this event has been fired.
 - __`.on('render')`__: when the DOM re-renders
 - __`.on('pushState')`__: when the history API is triggered
 
@@ -274,6 +274,7 @@ anchor links on the page is generally not recommended.
 New routes can be triggered through `emitter.emit('pushState', <routename>)`.
 By default we also catch and match all `<a href="">` clicks against the router.
 This can be disabled by setting `opts.href` to `false` in the constructor.
+Routing via `pushState` will not work until the `DOMContentLoaded` event has been fired.
 
 Querystrings (`?foo=bar`) are ignored when matching routes. They should be
 extracted from the `window.location` object on render events, from either a

--- a/README.md
+++ b/README.md
@@ -255,9 +255,15 @@ of [nanobus](https://github.com/yoshuawuyts/nanobus/). You can listen to
 messages by calling `emitter.on()` and emit messages by calling `emitter.emit()`.
 
 Choo fires messages when certain events happen:
-- __`.on('DOMContentLoaded')`__: when the DOM has succesfully finished loading. Re-rendering and navigation will not work until this event has been fired.
+- __`.on('DOMContentLoaded')`__: when the DOM has succesfully finished loading
 - __`.on('render')`__: when the DOM re-renders
 - __`.on('pushState')`__: when the history API is triggered
+
+The `render` event should be emitted (`emitter.emit('render')`) whenever you wan't the app to re-render the DOM - it won't happen on its own except when you navigate between routes.
+
+The `pushState` can be emitted to navigate between routes: `emitted.emit('pushState', '/some/route')`.
+
+Both `render` and `pushState` will only have an effect once the `DOMContentLoaded` event has been fired.
 
 ### `app.route(routeName, handler)`
 Register a route on the router. Uses [nanorouter][nanorouter] under the hood.


### PR DESCRIPTION
I've attempted to make clear some things that were unclear to me when I read the docs:

1. that the user must explicitly re-render the app by emitting the `render` event
2. that the `DOMContentLoaded` event is the signal that `render` and `pushState` can be used, and before this those events do nothing
