### PR TITLE
run choo event handlers first

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,14 +62,14 @@ function Choo (opts) {
       }
     })
 
-    bus.on('render', rerender)
+    bus.prependListener('render', rerender)
 
     if (opts.history !== false) {
       nanohistory(function (href) {
         bus.emit('pushState')
       })
 
-      bus.on('pushState', function (href) {
+      bus.prependListener('pushState', function (href) {
         if (href) window.history.pushState({}, null, href)
         bus.emit('render')
         setTimeout(function () {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "bel": "^4.5.1",
     "document-ready": "^2.0.1",
-    "nanobus": "^3.0.0",
+    "nanobus": "^3.1.0",
     "nanohistory": "^1.0.0",
     "nanohref": "^1.0.0",
     "nanomorph": "^4.0.0",


### PR DESCRIPTION
Fixes #463 by letting choo handle events before any other handlers run (unless other handlers explicitly want to run before choo through `.prependListener()` instead of `.on()`). Thanks!