### PR TITLE
warn on unmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ function Choo (opts) {
       }
       var newTree = router(createLocation())
       tree = nanomorph(tree, newTree)
+      assert.notEqual(tree, newTree, 'choo.start: a different node type was returned as the root node on a rerender. Make sure that the root node is always the same type to prevent the application from being unmounted.')
       if (hasPerformance && timingEnabled) {
         window.performance.mark('choo:renderEnd')
         window.performance.measure('choo:render', 'choo:renderStart', 'choo:renderEnd')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deps": "dependency-check --entry ./html.js . && dependency-check . --extra --no-dev --entry ./html.js",
     "inspect": "browserify --full-paths index -g unassertify -g uglifyify | discify --open",
     "prepublish": "npm run build",
-    "start": "bankai start example --optimize",
+    "start": "bankai start example",
     "test": "standard && npm run deps && node test.js"
   },
   "repository": "yoshuawuyts/choo",


### PR DESCRIPTION
Adds a runtime assertion to warn if the root node is being unmounted. Should help catch cases like https://github.com/yoshuawuyts/choo/issues/484. Perhaps this should be caught at the `nanomorph` layer, although: perhaps not. Anyway, hope this helps. Thanks!