### PR TITLE
Allow listeners to attach before rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ The `render` event should be emitted (`emitter.emit('render')`) whenever you wan
 
 The `pushState` can be emitted to navigate between routes: `emitted.emit('pushState', '/some/route')`.
 
-Both `render` and `pushState` will only have an effect once the `DOMContentLoaded` event has been fired.
+Note `render` will only have an effect once the `DOMContentLoaded` event has been fired.
 
 ### `app.route(routeName, handler)`
 Register a route on the router. Uses [nanorouter][nanorouter] under the hood.

--- a/index.js
+++ b/index.js
@@ -50,21 +50,6 @@ function Choo (opts) {
   }
 
   function start () {
-    rerender = nanoraf(function () {
-      if (hasPerformance && timingEnabled) {
-        window.performance.mark('choo:renderStart')
-      }
-      var newTree = router(createLocation())
-      tree = nanomorph(tree, newTree)
-      assert.notEqual(tree, newTree, 'choo.start: a different node type was returned as the root node on a rerender. Make sure that the root node is always the same type to prevent the application from being unmounted.')
-      if (hasPerformance && timingEnabled) {
-        window.performance.mark('choo:renderEnd')
-        window.performance.measure('choo:render', 'choo:renderStart', 'choo:renderEnd')
-      }
-    })
-
-    bus.prependListener('render', rerender)
-
     if (opts.history !== false) {
       nanohistory(function (href) {
         bus.emit('pushState')
@@ -88,11 +73,26 @@ function Choo (opts) {
       }
     }
 
-    tree = router(createLocation())
+    rerender = nanoraf(function () {
+      if (hasPerformance && timingEnabled) {
+        window.performance.mark('choo:renderStart')
+      }
+      var newTree = router(createLocation())
+      tree = nanomorph(tree, newTree)
+      assert.notEqual(tree, newTree, 'choo.start: a different node type was returned as the root node on a rerender. Make sure that the root node is always the same type to prevent the application from being unmounted.')
+      if (hasPerformance && timingEnabled) {
+        window.performance.mark('choo:renderEnd')
+        window.performance.measure('choo:render', 'choo:renderStart', 'choo:renderEnd')
+      }
+    })
+
+    bus.prependListener('render', rerender)
 
     documentReady(function () {
       bus.emit('DOMContentLoaded')
     })
+
+    tree = router(createLocation())
 
     return tree
   }

--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ function Choo (opts) {
   }
 
   function start () {
-    tree = router(createLocation())
     rerender = nanoraf(function () {
       if (hasPerformance && timingEnabled) {
         window.performance.mark('choo:renderStart')
@@ -88,6 +87,8 @@ function Choo (opts) {
         })
       }
     }
+
+    tree = router(createLocation())
 
     documentReady(function () {
       bus.emit('DOMContentLoaded')


### PR DESCRIPTION
This will allow `choo-redirect` to emit `pushState` on the first render. I'm not sure how to test this though.