### PR TITLE
Add hook for replaceState

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Choo fires messages when certain events happen:
 The `render` event should be emitted (`emitter.emit('render')`) whenever you want the app to re-render the DOM - it won't happen on its own except when you navigate between routes.
 
 The `pushState` can be emitted to navigate between routes: `emitted.emit('pushState', '/some/route')`.
-You can emit `replaceState` which will overwrite the current entry in the browser history, but be very careful with this!
+You can emit `replaceState` which will overwrite the current entry in the browser history, but be very careful as this removes the option of navigating back!
 
 Note `render` will only have an effect once the `DOMContentLoaded` event has been fired.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Choo fires messages when certain events happen:
 The `render` event should be emitted (`emitter.emit('render')`) whenever you want the app to re-render the DOM - it won't happen on its own except when you navigate between routes.
 
 The `pushState` can be emitted to navigate between routes: `emitted.emit('pushState', '/some/route')`.
+You can emit `replaceState` which will overwrite the current entry in the browser history, but be very careful with this!
 
 Note `render` will only have an effect once the `DOMContentLoaded` event has been fired.
 

--- a/index.js
+++ b/index.js
@@ -55,13 +55,16 @@ function Choo (opts) {
         bus.emit('pushState')
       })
 
-      bus.prependListener('pushState', function (href) {
-        if (href) window.history.pushState({}, null, href)
+      bus.prependListener('pushState', updateHistory.bind(null, 'push'))
+      bus.prependListener('replaceState', updateHistory.bind(null, 'replace'))
+
+      function updateHistory (mode) {
+        if (href) window.history[mode + 'State']({}, null, href)
         bus.emit('render')
         setTimeout(function () {
           scrollIntoView()
         }, 0)
-      })
+      }
 
       if (opts.href !== false) {
         nanohref(function (location) {


### PR DESCRIPTION
So history entries can be swapped without adding another entry. Like `301` redirects :)