### PR TITLE
pass through emit args to updateHistory

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function Choo (opts) {
       bus.prependListener('pushState', updateHistory.bind(null, 'push'))
       bus.prependListener('replaceState', updateHistory.bind(null, 'replace'))
 
-      function updateHistory (mode) {
+      function updateHistory (mode, href) {
         if (href) window.history[mode + 'State']({}, null, href)
         bus.emit('render')
         setTimeout(function () {


### PR DESCRIPTION
Since upgrading to `5.6.0` I am seeing the following error when calling `emit('pushState', '/route')`: 

```
ReferenceError: href is not defined
    at updateHistory (index.js:63)
    at Nanobus._emit (index.js:138)
    at Nanobus.emit (index.js:22)
    at emit (index.js:105)
    at fetch.post.then.res (login.js:13)
    at <anonymous>
```

#494 accidentally removed the `href` parameter from `updateHistory` by the looks of it. 