### PR TITLE
Wraps updateHistory calls in documentReady

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ anchor links on the page is generally not recommended.
 New routes can be triggered through `emitter.emit('pushState', <routename>)`.
 By default we also catch and match all `<a href="">` clicks against the router.
 This can be disabled by setting `opts.href` to `false` in the constructor.
-Routing via `pushState` will not work until the `DOMContentLoaded` event has been fired.
 
 If you need choo to ignore a particular route, you can add `data-no-routing`
 attribute with `<a href="" data-no-routing>`. This is especially useful for


### PR DESCRIPTION
This allows 'setState' and 'replaceState' to be used in models without checking whether the document is ready.

Since `documentReady` runs callbacks on the next tick if the document is already ready, this does change behavior slightly. It seems like it's fine to wait a tick, but I haven't investigated thoroughly.

Related to #470, which was solved by documenting the fact that history changes don't work before the document is ready.