### PR TITLE
Allow router to accept an object of routes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,16 +37,23 @@ function Choo (opts) {
   }
 
   function route (route, handler) {
-    router.on(route, function (params) {
-      return function () {
-        state.params = params
-        return handler(state, emit)
-      }
-    })
+    if ('object' === typeof route){
+      Object.keys(route).forEach(k=>route(k, route[k])
+    }
+    else {
+      router.on(route, function (params) {
+        return function () {
+          state.params = params
+          return handler(state, emit)
+        }
+      })
+    }
+    return this
   }
 
   function register (cb) {
     cb(state, bus)
+    return this
   }
 
   function start () {
@@ -112,6 +119,7 @@ function Choo (opts) {
       nanomount(root, newTree)
       tree = root
     })
+    return this
   }
 
   function toString (location, _state) {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function Choo (opts) {
 
   function route (route, handler) {
     if ('object' === typeof route){
-      Object.keys(route).forEach(k=>route(k, route[k])
+      Object.keys(route).forEach(k=>route(k, route[k]))
     }
     else {
       router.on(route, function (params) {


### PR DESCRIPTION
Define multiple routes with a single method call:

    app.route({
      '/': main
      ,'/other': (state, emit)=>html`some other content`
    })

Also, allow chaining:

    app.route('/', main)
          .route('/other', (state, emit)=>html`some other content`)