### PR TITLE
add DOMTitleChange event

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ will be a previous entry in the browser's history stack, and will emit
 `'navigate'` and `'render'`. Similar to
 [history.popState](http://devdocs.io/dom_events/popstate).
 
+### `'DOMTitleChange'`|`state.events.DOMTITLECHANGE`
+This event should be emitted whenever the `document.title` needs to be updated.
+It will set both `document.title` and `state.title`.  This value can be used
+when server rendering to accurately include a `<title>` tag in the header.
+This is derived from the
+[DOMTitleChanged event](https://developer.mozilla.org/en-US/docs/Web/Events/DOMTitleChanged).
+
 ## State
 Choo comes with a shared state object. This object can be mutated freely, and
 is passed into the view functions whenever `'render'` is emitted. The state
@@ -231,6 +238,9 @@ An object containing the current queryString. `/foo?bin=baz` becomes `{ bin:
 
 ### `state.route`
 The current name of the route used in the router (e.g. `/foo/:bar`).
+
+### `state.title`
+The current page title. Can be set using the `DOMTitleChange` event.
 
 ## Routing
 Choo is an application level framework. This means that it takes care of


### PR DESCRIPTION
Was playing around with lighthouse, and one of the things they want is a title tag. I realized we don't have a good story for setting titles yet, but given it's necessary for accessibility I figured we might want to. This patch introduces a new event called `'DOMTitleChange'` which is somewhat similar to [`'DOMTitleChanged'`](https://developer.mozilla.org/en-US/docs/Web/Events/DOMTitleChanged) with the difference that it's triggered rather than listened on.

This also introduces a `state.title` property which holds the current page title. Updating the title would look somewhat like this:
```js
var title = 'Cool Website | main page'
app.route('/foo', function (state, emit) {
  if (state.title !== title) emit(state.events.DOMTITLECHANGE, title)
  return html`<div>ohey cool humans</div>`
})
```